### PR TITLE
feat: auto-liner

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -31,6 +31,7 @@
   - [Authorizable](detailed/utils/authorizable.md)
   - [Modifiable](detailed/utils/modifiable.md)
   - [Disableable](detailed/utils/disableable.md)
+  - [AutoLiner](detailed/utils/autoliner.md)
   - [❱ Factories](detailed/utils/factory/README.md)
     - [Factory Child](detailed/utils/factory/factory_child.md)
     - [Authorizable Child](detailed/utils/factory/authorizable_child.md)

--- a/docs/src/detailed/utils/autoliner.md
+++ b/docs/src/detailed/utils/autoliner.md
@@ -1,0 +1,237 @@
+# AutoLiner
+
+See [AutoLiner.sol](/src/contracts/utils/AutoLiner.sol/contract.AutoLiner.html) for the implementation details.
+
+## 1. Purpose
+
+`AutoLiner` maintains the live `SAFEEngine.debtCeiling` for a collateral type so there is always controlled minting headroom above the current debt while respecting:
+
+- a governance-defined ceiling cap
+- a minimum live ceiling floor
+- a cooldown between any two live ceiling changes
+
+The contract is designed to be an execution utility. Governance configures it, and a keeper or operator calls `updateCeiling(cType)` over time.
+
+## 2. Product Requirements
+
+### Goal
+
+For each initialized collateral type, the live ceiling should follow this rule:
+
+- target ceiling is `min(max(minDebt, currentDebt + gap), ceilingCap)`
+
+Special case:
+
+- if `gap == type(uint256).max`, target ceiling is exactly `ceilingCap`
+
+### Global Params
+
+- `cooldown`: minimum delay between any two live ceiling changes
+
+### Per-Collateral Params
+
+- `ceilingCap`: local ceiling cap for the collateral
+- `minDebt`: local minimum live ceiling
+- `gap`: local headroom
+
+### Per-Collateral State
+
+- `lastUpdateTime`: timestamp of the last successful live ceiling change
+
+## 3. Source Of Truth
+
+`AutoLiner` uses two distinct sources, with separate responsibilities:
+
+- local `AutoLiner` params are the source of truth for the wanted cap and local tuning
+- live collateral configuration in `SAFEEngine` is the currently enforced ceiling
+
+### Before Enabling AutoLiner
+
+Before a collateral is initialized in `AutoLiner`, `SAFEEngine` is both:
+
+- the source of truth for the collateral debt ceiling
+- the contract that enforces that ceiling
+
+In that mode, governance only has one relevant ceiling value:
+
+- `SAFEEngine.debtCeiling` is the wanted ceiling
+- `SAFEEngine.debtCeiling` is also the live enforced ceiling
+
+### After Enabling AutoLiner
+
+Once a collateral is initialized in `AutoLiner` with a non-zero `ceilingCap`, those responsibilities split:
+
+- `AutoLiner.cParams(cType).ceilingCap` becomes the source of truth for the wanted maximum ceiling
+- `SAFEEngine.cParams(cType).debtCeiling` becomes the live enforced ceiling that `AutoLiner` moves over time
+
+This is the key design change introduced by `AutoLiner`:
+
+- before `AutoLiner`, the same storage slot in `SAFEEngine` means both "what governance wants" and "what is currently enforced"
+- after `AutoLiner`, governance expresses the wanted cap in `AutoLiner`, while `SAFEEngine` holds the currently applied live ceiling
+
+So when `AutoLiner` is enabled:
+
+- governance should treat `AutoLiner.ceilingCap` as the desired cap
+- governance should treat `SAFEEngine.debtCeiling` as the current execution value
+- `AutoLiner.updateCeiling(cType)` is the mechanism that reconciles the live SAFEEngine ceiling with the locally configured AutoLiner target
+
+For a collateral type to be managed:
+
+1. it must be initialized in `AutoLiner` through `initializeCollateralType`
+2. it must have a non-zero local `ceilingCap` in `AutoLiner`
+3. it must have a non-zero live `debtCeiling` in `SAFEEngine`
+
+This creates two separate gates:
+
+- not initialized in `AutoLiner` -> revert `AutoLiner_CollateralTypeNotInitialized`
+- initialized in `AutoLiner` but deactivated locally -> revert `AutoLiner_CollateralTypeNotActive`
+- initialized in `AutoLiner` but disabled in `SAFEEngine` -> revert `AutoLiner_CollateralTypeNotRegistered`
+
+## 4. Ceiling Cap Resolution
+
+`ceilingCap` is a local AutoLiner control value:
+
+- if local `ceilingCap > 0`, it is the effective cap
+- if local `ceilingCap == 0`, the collateral is inactive in `AutoLiner`
+
+Initialization rule:
+
+- `initializeCollateralType` requires `ceilingCap > 0`
+- `initializeCollateralType` requires `minDebt > 0`
+- `initializeCollateralType` requires `gap > 0`
+- after initialization, governance may later set `ceilingCap = 0` through `modifyParameters` to deactivate the collateral in `AutoLiner`
+
+Notice:
+
+- `minDebt` is enforced as a floor at all debt levels
+- the target formula is continuous as debt moves to or from zero
+- `gap = 0` and `minDebt = 0` are invalid config values
+
+## 5. Operational Procedures
+
+### Onboard A Collateral
+
+1. Initialize the collateral in `SAFEEngine` with a non-zero `debtCeiling`
+2. Initialize the collateral in `AutoLiner` with:
+
+```solidity
+AutoLinerCollateralParams({
+  ceilingCap: <wanted ceiling cap>,
+  minDebt: <minimum live ceiling>,
+  gap: <headroom>
+})
+```
+
+3. Authorize `AutoLiner` on `SAFEEngine`
+4. Call `updateCeiling(cType)`
+
+Result:
+
+- local `ceilingCap` is the source of truth for the collateral cap
+- the resulting target follows the same continuous formula used at all debt levels
+- from this point onward, `SAFEEngine.debtCeiling` should be understood as the live enforced ceiling, not the governance source of truth for the desired cap
+- if governance later sets `AutoLiner.ceilingCap = 0` for the collateral, `AutoLiner` stops managing that live ceiling and governance must manually set the wanted target directly in `SAFEEngine`
+
+### Change Per-Collateral Params After Onboarding
+
+1. Ensure the collateral was already initialized in `AutoLiner`
+2. Call `modifyParameters(cType, param, data)`
+
+Notice:
+
+- changing params does not change the live SAFEEngine ceiling by itself
+- setting `ceilingCap = 0` deactivates the collateral in `AutoLiner`
+- setting `minDebt = 0` reverts
+- setting `gap = 0` reverts
+- local deactivation is not the same as live ceiling shutdown:
+  setting `ceilingCap = 0` stops future AutoLiner management, but leaves the current live `SAFEEngine.debtCeiling` unchanged
+- if governance deactivates AutoLiner locally and also wants a different enforced ceiling, governance must modify `SAFEEngine.debtCeiling` separately
+
+### Disable A Collateral
+
+1. Set `SAFEEngine.debtCeiling = 0`
+
+Result:
+
+- future `updateCeiling(cType)` calls revert with `AutoLiner_CollateralTypeNotRegistered`
+- local `AutoLiner` config remains stored
+- if local `ceilingCap > 0`, the collateral remains locally active in `AutoLiner`
+- execution is blocked because the live `SAFEEngine.debtCeiling` gate is now zero
+
+### Deactivate AutoLiner Locally
+
+1. Set `AutoLiner.ceilingCap = 0` through `modifyParameters`
+
+Result:
+
+- future `getNextDebtCeiling(cType)` and `updateCeiling(cType)` calls revert with `AutoLiner_CollateralTypeNotActive`
+- the current live `SAFEEngine.debtCeiling` is not changed by this action
+- if governance wants to change the enforced live ceiling after local deactivation, governance must modify `SAFEEngine.debtCeiling` separately
+
+### Restore A Disabled Collateral
+
+1. Set `SAFEEngine.debtCeiling` back to a non-zero value
+2. Call `updateCeiling(cType)`
+
+If local `ceilingCap > 0`, it remains the local source of truth.
+If local `ceilingCap == 0`, `updateCeiling` continues to revert until governance reactivates the collateral by setting a non-zero cap.
+
+## 6. Keeper Procedure
+
+For each managed collateral type:
+
+1. ensure the collateral is initialized in `AutoLiner`
+2. ensure the collateral has a non-zero local `ceilingCap`
+3. ensure the collateral has a non-zero live ceiling in `SAFEEngine`
+4. if you want only a preview, call `getNextDebtCeiling(cType)`
+5. call `updateCeiling(cType)`
+6. both `getNextDebtCeiling(cType)` and `updateCeiling(cType)` revert if the live `SAFEEngine.debtCeiling` is zero
+7. if the target equals the current live ceiling, the update call is a no-op
+8. if the target differs and cooldown has not passed, the update call reverts
+9. if the target differs and cooldown has passed, the live ceiling is updated in `SAFEEngine`
+
+## 7. Test Coverage
+
+### Unit Tests
+
+The suite in [test/unit/AutoLiner.t.sol](/test/unit/AutoLiner.t.sol) currently checks:
+
+- constructor validation
+- global parameter modification
+- rejection of unsupported global params such as `safeEngine`
+- mandatory `AutoLiner` initialization before collateral-specific config or execution
+- `ceilingCap > 0`, `minDebt > 0`, and `gap > 0` requirements during initialization
+- explicit per-collateral initialization storage
+- duplicate initialization revert
+- local per-collateral parameter modification after initialization
+- explicit local deactivation through `ceilingCap = 0`
+- rejection of `minDebt = 0` and `gap = 0`
+- `minDebt` acting as a floor when `currentDebt + gap` is smaller than `minDebt`
+- `gap == type(uint256).max` returning the effective cap
+- cooldown enforcement for both increases and decreases
+- clamping to `ceilingCap`
+- no-op updates preserving `lastUpdateTime`
+- distinction between:
+  - not initialized in `AutoLiner`
+  - initialized in `AutoLiner` but inactive in `AutoLiner`
+  - initialized in `AutoLiner` but disabled in `SAFEEngine`
+
+### E2E Tests
+
+The suite in [test/e2e/E2EAutoLiner.t.sol](/test/e2e/E2EAutoLiner.t.sol) currently checks:
+
+- debt generation followed by ceiling reduction to the computed target, including the `minDebt` floor and `ceilingCap` clamp rules
+- cooldown blocking intermediate updates
+- post-cooldown re-expansion when debt increases
+- post-cooldown reduction back to `minDebt` after full repayment
+- `gap == type(uint256).max` causing the live ceiling to return directly to the local `ceilingCap`
+
+## 8. Key Invariants
+
+- a collateral must be initialized in `AutoLiner` before it can be managed
+- an initialized collateral with `ceilingCap == 0` is inactive in `AutoLiner`
+- `minDebt` must never be zero for a valid initialized collateral config
+- `gap` must never be zero for a valid initialized collateral config
+- a collateral must have non-zero live `SAFEEngine.debtCeiling` to be actively managed
+- `lastUpdateTime` only changes when the live ceiling actually changes
+- `ceilingCap` is always sourced from local `AutoLiner` params

--- a/src/contracts/utils/AutoLiner.sol
+++ b/src/contracts/utils/AutoLiner.sol
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.20;
+
+import {ISAFEEngine} from '@interfaces/ISAFEEngine.sol';
+import {IAutoLiner} from '@interfaces/utils/IAutoLiner.sol';
+
+import {Authorizable} from '@contracts/utils/Authorizable.sol';
+import {Modifiable} from '@contracts/utils/Modifiable.sol';
+import {ModifiablePerCollateral} from '@contracts/utils/ModifiablePerCollateral.sol';
+import {EnumerableSet} from '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+
+import {Assertions} from '@libraries/Assertions.sol';
+import {Encoding} from '@libraries/Encoding.sol';
+import {Math} from '@libraries/Math.sol';
+
+/**
+ * @title  AutoLiner
+ * @notice Maintains a live collateral debt ceiling in the SAFEEngine with a configurable minting headroom
+ */
+contract AutoLiner is Authorizable, Modifiable, ModifiablePerCollateral, IAutoLiner {
+  using Assertions for uint256;
+  using Assertions for address;
+  using Encoding for bytes;
+  using EnumerableSet for EnumerableSet.Bytes32Set;
+
+  // --- Registry ---
+
+  ISAFEEngine public safeEngine;
+
+  // --- Params ---
+
+  // solhint-disable-next-line private-vars-leading-underscore
+  AutoLinerParams public _params;
+
+  /// @inheritdoc IAutoLiner
+  function params() external view returns (AutoLinerParams memory _autoLinerParams) {
+    return _params;
+  }
+
+  // solhint-disable-next-line private-vars-leading-underscore
+  mapping(bytes32 _cType => AutoLinerCollateralParams) public _cParams;
+
+  /// @inheritdoc IAutoLiner
+  function cParams(bytes32 _cType) external view returns (AutoLinerCollateralParams memory _autoLinerCParams) {
+    return _cParams[_cType];
+  }
+
+  // --- Data ---
+
+  // solhint-disable-next-line private-vars-leading-underscore
+  mapping(bytes32 _cType => AutoLinerCollateralData) public _cData;
+
+  /// @inheritdoc IAutoLiner
+  function cData(bytes32 _cType) external view returns (AutoLinerCollateralData memory _autoLinerCData) {
+    return _cData[_cType];
+  }
+
+  // --- Init ---
+
+  /**
+   * @param _safeEngine Address of the SAFEEngine contract
+   * @param _autoLinerParams Initial valid AutoLiner parameters
+   */
+  constructor(address _safeEngine, AutoLinerParams memory _autoLinerParams) Authorizable(msg.sender) validParams {
+    safeEngine = ISAFEEngine(_safeEngine.assertHasCode());
+    _params = _autoLinerParams;
+  }
+
+  // --- Views ---
+
+  /// @inheritdoc IAutoLiner
+  function getNextDebtCeiling(bytes32 _cType) external view returns (uint256 _nextDebtCeiling) {
+    _ensureAutoLinerCollateral(_cType);
+    _getLiveDebtCeiling(_cType);
+    return _getNextDebtCeiling(_cType);
+  }
+
+  // --- Methods ---
+
+  /// @inheritdoc IAutoLiner
+  function updateCeiling(bytes32 _cType) external returns (uint256 _nextDebtCeiling) {
+    _ensureAutoLinerCollateral(_cType);
+    uint256 _currentDebtCeiling = _getLiveDebtCeiling(_cType);
+
+    _nextDebtCeiling = _getNextDebtCeiling(_cType);
+
+    if (_nextDebtCeiling == _currentDebtCeiling) return _nextDebtCeiling;
+    if (!_cooldownPassed(_cType)) revert AutoLiner_Cooldown();
+
+    _cData[_cType].lastUpdateTime = block.timestamp;
+    safeEngine.modifyParameters(_cType, 'debtCeiling', abi.encode(_nextDebtCeiling));
+
+    emit UpdateCeiling(_cType, _currentDebtCeiling, _nextDebtCeiling);
+  }
+
+  // --- Administration ---
+
+  /// @inheritdoc ModifiablePerCollateral
+  function _initializeCollateralType(bytes32 _cType, bytes memory _collateralParams) internal override {
+    AutoLinerCollateralParams memory _decodedParams = abi.decode(_collateralParams, (AutoLinerCollateralParams));
+    if (_decodedParams.ceilingCap == 0) revert AutoLiner_NullCeilingCap();
+    _cParams[_cType] = _decodedParams;
+  }
+
+  /// @inheritdoc Modifiable
+  function _modifyParameters(bytes32 _param, bytes memory _data) internal override {
+    uint256 _uint256 = _data.toUint256();
+
+    if (_param == 'cooldown') _params.cooldown = _uint256;
+    else revert UnrecognizedParam();
+  }
+
+  function _modifyParameters(bytes32 _cType, bytes32 _param, bytes memory _data) internal override {
+    uint256 _uint256 = _data.toUint256();
+
+    if (!_collateralList.contains(_cType)) revert UnrecognizedCType();
+    if (_param == 'ceilingCap') _cParams[_cType].ceilingCap = _uint256;
+    else if (_param == 'minDebt') _cParams[_cType].minDebt = _uint256;
+    else if (_param == 'gap') _cParams[_cType].gap = _uint256;
+    else revert UnrecognizedParam();
+  }
+
+  /// @inheritdoc Modifiable
+  function _validateParameters() internal view override {
+    address(safeEngine).assertHasCode();
+  }
+
+  /// @inheritdoc ModifiablePerCollateral
+  function _validateCParameters(bytes32 _cType) internal view override {
+    if (_cParams[_cType].minDebt == 0) revert AutoLiner_NullMinDebt();
+    if (_cParams[_cType].gap == 0) revert AutoLiner_NullGap();
+  }
+
+  // --- Internal ---
+
+  function _getNextDebtCeiling(bytes32 _cType) internal view returns (uint256 _nextDebtCeiling) {
+    AutoLinerCollateralParams memory __cParams = _cParams[_cType];
+    uint256 _ceilingCap = __cParams.ceilingCap;
+    uint256 _minDebt = __cParams.minDebt;
+    uint256 _gap = __cParams.gap;
+
+    if (_gap == type(uint256).max) return _ceilingCap;
+
+    uint256 _currentDebt = _getCurrentDebt(_cType);
+    if (_currentDebt >= _ceilingCap) return _ceilingCap;
+
+    uint256 _remainingHeadroom = _ceilingCap - _currentDebt;
+    uint256 _debtPlusGap = _currentDebt + Math.min(_gap, _remainingHeadroom);
+    return Math.min(_ceilingCap, Math.max(_minDebt, _debtPlusGap));
+  }
+
+  function _getCurrentDebt(bytes32 _cType) internal view returns (uint256 _currentDebt) {
+    ISAFEEngine.SAFEEngineCollateralData memory _safeEngineCData = safeEngine.cData(_cType);
+    return _safeEngineCData.debtAmount * _safeEngineCData.accumulatedRate;
+  }
+
+  function _getLiveDebtCeiling(bytes32 _cType) internal view returns (uint256 _liveDebtCeiling) {
+    _liveDebtCeiling = safeEngine.cParams(_cType).debtCeiling;
+    if (_liveDebtCeiling == 0) revert AutoLiner_CollateralTypeNotRegistered();
+    return _liveDebtCeiling;
+  }
+
+  function _cooldownPassed(bytes32 _cType) internal view returns (bool _passed) {
+    uint256 _lastUpdateTime = _cData[_cType].lastUpdateTime;
+    return _lastUpdateTime == 0 || block.timestamp - _lastUpdateTime >= _params.cooldown;
+  }
+
+  function _ensureAutoLinerCollateral(bytes32 _cType) internal view {
+    if (!_collateralList.contains(_cType)) revert AutoLiner_CollateralTypeNotInitialized();
+    if (_cParams[_cType].ceilingCap == 0) revert AutoLiner_CollateralTypeNotActive();
+  }
+}

--- a/src/contracts/utils/ModifiablePerCollateral.sol
+++ b/src/contracts/utils/ModifiablePerCollateral.sol
@@ -55,8 +55,8 @@ abstract contract ModifiablePerCollateral is Authorizable, IModifiablePerCollate
   function _modifyParameters(bytes32 _cType, bytes32 _param, bytes memory _data) internal virtual;
 
   /**
-   * @notice Register a new collateral type in the SAFEEngine
-   * @param _cType Collateral type to register
+   * @notice Initialize a new collateral type in the inheriting contract
+   * @param _cType Collateral type to initialize
    * @param _collateralParams Collateral parameters
    */
   function _initializeCollateralType(bytes32 _cType, bytes memory _collateralParams) internal virtual;

--- a/src/interfaces/utils/IAutoLiner.sol
+++ b/src/interfaces/utils/IAutoLiner.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.20;
+
+import {ISAFEEngine} from '@interfaces/ISAFEEngine.sol';
+
+import {IAuthorizable} from '@interfaces/utils/IAuthorizable.sol';
+import {IModifiable} from '@interfaces/utils/IModifiable.sol';
+import {IModifiablePerCollateral} from '@interfaces/utils/IModifiablePerCollateral.sol';
+
+interface IAutoLiner is IAuthorizable, IModifiable, IModifiablePerCollateral {
+  // --- Events ---
+
+  /**
+   * @notice Emitted when the live debt ceiling is updated in the SAFEEngine
+   * @param _cType Bytes32 representation of the collateral type
+   * @param _oldDebtCeiling Previous live debt ceiling [rad]
+   * @param _newDebtCeiling New live debt ceiling [rad]
+   */
+  event UpdateCeiling(bytes32 indexed _cType, uint256 _oldDebtCeiling, uint256 _newDebtCeiling);
+  // --- Errors ---
+
+  /// @notice Throws when trying to update a ceiling before the cooldown has passed
+  error AutoLiner_Cooldown();
+  /// @notice Throws when the collateral type has not been initialized in AutoLiner
+  error AutoLiner_CollateralTypeNotInitialized();
+  /// @notice Throws when the collateral type is initialized but inactive in AutoLiner
+  error AutoLiner_CollateralTypeNotActive();
+  /// @notice Throws when the collateral type is not registered in the SAFEEngine
+  error AutoLiner_CollateralTypeNotRegistered();
+  /// @notice Throws when trying to initialize a collateral type with a zero ceiling cap
+  error AutoLiner_NullCeilingCap();
+  /// @notice Throws when the collateral headroom is zero
+  error AutoLiner_NullGap();
+  /// @notice Throws when the effective minimum debt ceiling is zero
+  error AutoLiner_NullMinDebt();
+
+  // --- Structs ---
+
+  struct AutoLinerParams {
+    // Minimum delay between any two live ceiling changes
+    uint256 /* seconds */ cooldown;
+  }
+
+  struct AutoLinerCollateralParams {
+    // Maximum live debt ceiling that can be restored for the collateral
+    uint256 /* RAD */ ceilingCap;
+    // Collateral specific minimum live debt ceiling floor
+    uint256 /* RAD */ minDebt;
+    // Collateral specific headroom to leave above the current debt
+    uint256 /* RAD */ gap;
+  }
+
+  struct AutoLinerCollateralData {
+    // Timestamp of the last live ceiling update
+    uint256 /* seconds */ lastUpdateTime;
+  }
+
+  // --- Registry ---
+
+  /**
+   * @notice SAFEEngine where live collateral debt ceilings are stored
+   */
+  function safeEngine() external view returns (ISAFEEngine _safeEngine);
+
+  // --- Params ---
+
+  /**
+   * @notice Getter for the contract parameters struct
+   * @return _autoLinerParams The active AutoLinerParams
+   */
+  function params() external view returns (AutoLinerParams memory _autoLinerParams);
+
+  /**
+   * @notice Getter for the collateral parameters struct
+   * @param _cType Bytes32 representation of the collateral type
+   * @return _autoLinerCParams The active AutoLinerCollateralParams
+   */
+  function cParams(bytes32 _cType) external view returns (AutoLinerCollateralParams memory _autoLinerCParams);
+
+  // --- Data ---
+
+  /**
+   * @notice Getter for the collateral state struct
+   * @param _cType Bytes32 representation of the collateral type
+   * @return _autoLinerCData The active AutoLinerCollateralData
+   */
+  function cData(bytes32 _cType) external view returns (AutoLinerCollateralData memory _autoLinerCData);
+
+  // --- Views ---
+
+  /**
+   * @notice Compute the next live debt ceiling for a collateral type
+   * @param _cType Bytes32 representation of the collateral type
+   * @return _nextDebtCeiling The next live debt ceiling [rad]
+   */
+  function getNextDebtCeiling(bytes32 _cType) external view returns (uint256 _nextDebtCeiling);
+
+  // --- Methods ---
+
+  /**
+   * @notice Update the live debt ceiling for a collateral type in the SAFEEngine
+   * @param _cType Bytes32 representation of the collateral type
+   * @return _nextDebtCeiling The live debt ceiling that should apply after the call [rad]
+   */
+  function updateCeiling(bytes32 _cType) external returns (uint256 _nextDebtCeiling);
+}

--- a/src/interfaces/utils/IModifiablePerCollateral.sol
+++ b/src/interfaces/utils/IModifiablePerCollateral.sol
@@ -27,8 +27,8 @@ interface IModifiablePerCollateral is IAuthorizable, IModifiable {
   // --- Methods ---
 
   /**
-   * @notice Register a new collateral type in the SAFEEngine
-   * @param _cType Collateral type to register
+   * @notice Initialize a new collateral type in the implementing contract
+   * @param _cType Collateral type to initialize
    * @param _collateralParams Collateral parameters
    */
   function initializeCollateralType(bytes32 _cType, bytes memory _collateralParams) external;

--- a/test/e2e/E2EAutoLiner.t.sol
+++ b/test/e2e/E2EAutoLiner.t.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.20;
+
+import {Common, COLLAT, TKN} from './Common.t.sol';
+import {AutoLiner} from '@contracts/utils/AutoLiner.sol';
+import {IAutoLiner} from '@interfaces/utils/IAutoLiner.sol';
+import {ISAFEEngine} from '@interfaces/ISAFEEngine.sol';
+import {RAY} from '@libraries/Math.sol';
+
+import {BaseUser} from '@test/scopes/BaseUser.t.sol';
+import {DirectUser} from '@test/scopes/DirectUser.t.sol';
+
+abstract contract E2EAutoLinerTest is BaseUser, Common {
+  AutoLiner autoLiner;
+
+  uint256 minDebt = rad(100 ether);
+  uint256 gap = rad(50 ether);
+  uint256 cooldown = 12 hours;
+
+  function setUp() public virtual override {
+    super.setUp();
+
+    vm.startPrank(deployer);
+    autoLiner = new AutoLiner(address(safeEngine), IAutoLiner.AutoLinerParams({cooldown: cooldown}));
+    autoLiner.initializeCollateralType(
+      TKN,
+      abi.encode(
+        IAutoLiner.AutoLinerCollateralParams({
+          ceilingCap: safeEngine.cParams(TKN).debtCeiling, minDebt: minDebt, gap: gap
+        })
+      )
+    );
+    safeEngine.addAuthorization(address(autoLiner));
+    vm.stopPrank();
+  }
+
+  function rad(uint256 _wad) internal pure returns (uint256 _rad) {
+    return _wad * RAY;
+  }
+
+  function _currentDebt(bytes32 _cType) internal view returns (uint256 _currentDebtRad) {
+    ISAFEEngine.SAFEEngineCollateralData memory _cData = safeEngine.cData(_cType);
+    return _cData.debtAmount * _cData.accumulatedRate;
+  }
+
+  function test_update_ceiling_follow_debt_and_cooldown() public {
+    _generateDebt(alice, address(collateralJoin[TKN]), int256(1000 * COLLAT), int256(500 ether));
+
+    uint256 _firstCurrentDebt = _currentDebt(TKN);
+    uint256 _firstExpectedCeiling = _firstCurrentDebt + gap;
+
+    autoLiner.updateCeiling(TKN);
+
+    assertEq(safeEngine.cParams(TKN).debtCeiling, _firstExpectedCeiling);
+
+    _generateDebt(alice, address(collateralJoin[TKN]), int256(100 * COLLAT), int256(50 ether));
+
+    uint256 _secondCurrentDebt = _currentDebt(TKN);
+    uint256 _secondExpectedCeiling = _secondCurrentDebt + gap;
+
+    vm.expectRevert(IAutoLiner.AutoLiner_Cooldown.selector);
+    autoLiner.updateCeiling(TKN);
+
+    vm.warp(block.timestamp + cooldown);
+    autoLiner.updateCeiling(TKN);
+
+    assertEq(safeEngine.cParams(TKN).debtCeiling, _secondExpectedCeiling);
+
+    (uint256 _generatedDebt, uint256 _lockedCollateral) = _getSafeStatus(TKN, alice);
+    _repayDebtAndExit(alice, address(collateralJoin[TKN]), _lockedCollateral, _generatedDebt);
+
+    vm.expectRevert(IAutoLiner.AutoLiner_Cooldown.selector);
+    autoLiner.updateCeiling(TKN);
+
+    vm.warp(block.timestamp + cooldown);
+    autoLiner.updateCeiling(TKN);
+
+    assertEq(_currentDebt(TKN), 0);
+    assertEq(safeEngine.cParams(TKN).debtCeiling, minDebt);
+  }
+
+  function test_update_ceiling_return_cap_when_gap_is_max_uint() public {
+    vm.prank(deployer);
+    autoLiner.modifyParameters(TKN, 'gap', abi.encode(type(uint256).max));
+
+    uint256 _ceilingCap = autoLiner.cParams(TKN).ceilingCap;
+    uint256 _lowerLiveCeiling = rad(1000 ether);
+
+    vm.prank(deployer);
+    safeEngine.modifyParameters(TKN, 'debtCeiling', abi.encode(_lowerLiveCeiling));
+
+    autoLiner.updateCeiling(TKN);
+
+    assertEq(autoLiner.cParams(TKN).ceilingCap, _ceilingCap);
+    assertEq(safeEngine.cParams(TKN).debtCeiling, _ceilingCap);
+  }
+}
+
+contract E2EAutoLinerTestDirectUser is DirectUser, E2EAutoLinerTest {}

--- a/test/unit/AutoLiner.t.sol
+++ b/test/unit/AutoLiner.t.sol
@@ -1,0 +1,437 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.20;
+
+import {AutoLiner} from '@contracts/utils/AutoLiner.sol';
+import {IAutoLiner} from '@interfaces/utils/IAutoLiner.sol';
+import {SAFEEngineForTest, ISAFEEngine} from '@test/mocks/SAFEEngineForTest.sol';
+import {IAuthorizable} from '@interfaces/utils/IAuthorizable.sol';
+import {IModifiable} from '@interfaces/utils/IModifiable.sol';
+import {HaiTest, stdStorage, StdStorage} from '@test/utils/HaiTest.t.sol';
+
+import {Assertions} from '@libraries/Assertions.sol';
+import {RAY} from '@libraries/Math.sol';
+
+abstract contract Base is HaiTest {
+  using stdStorage for StdStorage;
+
+  event ModifyParameters(bytes32 indexed _param, bytes32 indexed _cType, bytes _data);
+  event UpdateCeiling(bytes32 indexed _cType, uint256 _oldDebtCeiling, uint256 _newDebtCeiling);
+  event InitializeCollateralType(bytes32 _cType);
+
+  address deployer = label('deployer');
+  address authorizedAccount = label('authorizedAccount');
+  address user = label('user');
+
+  bytes32 collateralType = 'collateralType';
+  bytes32 unregisteredCollateralType = 'unregisteredCollateralType';
+
+  uint256 minDebt = rad(100 ether);
+  uint256 gap = rad(50 ether);
+  uint256 cooldown = 12 hours;
+  uint256 liveDebtCeiling = rad(1000 ether);
+
+  SAFEEngineForTest safeEngine;
+  AutoLiner autoLiner;
+
+  function setUp() public virtual {
+    vm.startPrank(deployer);
+
+    safeEngine = new SAFEEngineForTest(
+      ISAFEEngine.SAFEEngineParams({safeDebtCeiling: type(uint256).max, globalDebtCeiling: type(uint256).max})
+    );
+    safeEngine.initializeCollateralType(
+      collateralType, abi.encode(ISAFEEngine.SAFEEngineCollateralParams({debtCeiling: liveDebtCeiling, debtFloor: 0}))
+    );
+
+    autoLiner = new AutoLiner(address(safeEngine), IAutoLiner.AutoLinerParams({cooldown: cooldown}));
+    autoLiner.addAuthorization(authorizedAccount);
+    autoLiner.initializeCollateralType(
+      collateralType,
+      abi.encode(IAutoLiner.AutoLinerCollateralParams({ceilingCap: liveDebtCeiling, minDebt: minDebt, gap: gap}))
+    );
+    safeEngine.addAuthorization(address(autoLiner));
+
+    vm.stopPrank();
+  }
+
+  modifier authorized() {
+    vm.startPrank(deployer);
+    _;
+    vm.stopPrank();
+  }
+
+  function rad(uint256 _wad) internal pure returns (uint256 _rad) {
+    return _wad * RAY;
+  }
+
+  function _mockCurrentDebt(bytes32 _cType, uint256 _debtRad) internal {
+    stdstore.target(address(safeEngine)).sig(ISAFEEngine.cData.selector).with_key(_cType).depth(0)
+      .checked_write(_debtRad / RAY);
+    stdstore.target(address(safeEngine)).sig(ISAFEEngine.cData.selector).with_key(_cType).depth(2).checked_write(RAY);
+  }
+
+  function _mockLastUpdateTime(bytes32 _cType, uint256 _lastUpdateTime) internal {
+    stdstore.target(address(autoLiner)).sig(IAutoLiner.cData.selector).with_key(_cType).depth(0)
+      .checked_write(_lastUpdateTime);
+  }
+
+  function _setLiveDebtCeiling(bytes32 _cType, uint256 _debtCeiling) internal {
+    vm.prank(deployer);
+    safeEngine.modifyParameters(_cType, 'debtCeiling', abi.encode(_debtCeiling));
+  }
+}
+
+contract Unit_AutoLiner_Constructor is Base {
+  function test_Set_SafeEngine() public {
+    assertEq(address(autoLiner.safeEngine()), address(safeEngine));
+  }
+
+  function test_Set_Params() public {
+    IAutoLiner.AutoLinerParams memory _params = autoLiner.params();
+
+    assertEq(_params.cooldown, cooldown);
+  }
+
+  function test_Set_AuthorizedAccounts() public {
+    assertEq(autoLiner.authorizedAccounts(deployer), true);
+    assertEq(autoLiner.authorizedAccounts(authorizedAccount), true);
+  }
+
+  function test_Revert_NullSafeEngine() public {
+    vm.expectRevert(abi.encodeWithSelector(Assertions.NoCode.selector, address(0)));
+    new AutoLiner(address(0), IAutoLiner.AutoLinerParams({cooldown: cooldown}));
+  }
+}
+
+contract Unit_AutoLiner_ModifyParameters is Base {
+  function test_Revert_ModifyParameters_Global_Unauthorized() public {
+    vm.expectRevert(IAuthorizable.Unauthorized.selector);
+    autoLiner.modifyParameters('cooldown', abi.encode(cooldown + 1));
+  }
+
+  function test_Revert_ModifyParameters_Collateral_Unauthorized() public {
+    vm.expectRevert(IAuthorizable.Unauthorized.selector);
+    autoLiner.modifyParameters(collateralType, 'gap', abi.encode(gap + 1));
+  }
+
+  function test_ModifyParameters_Global_Cooldown() public authorized {
+    uint256 _newCooldown = cooldown + 1;
+    autoLiner.modifyParameters('cooldown', abi.encode(_newCooldown));
+
+    assertEq(autoLiner.params().cooldown, _newCooldown);
+  }
+
+  function test_ModifyParameters_Collateral_SetGap_WithoutSeedingCap() public authorized {
+    uint256 _newGap = rad(25 ether);
+
+    vm.expectEmit();
+    emit ModifyParameters('gap', collateralType, abi.encode(_newGap));
+
+    autoLiner.modifyParameters(collateralType, 'gap', abi.encode(_newGap));
+
+    IAutoLiner.AutoLinerCollateralParams memory _cParams = autoLiner.cParams(collateralType);
+    assertEq(_cParams.ceilingCap, liveDebtCeiling);
+    assertEq(_cParams.gap, _newGap);
+  }
+
+  function test_ModifyParameters_Collateral_SetMinDebt() public authorized {
+    uint256 _newMinDebt = rad(200 ether);
+    autoLiner.modifyParameters(collateralType, 'minDebt', abi.encode(_newMinDebt));
+
+    assertEq(autoLiner.cParams(collateralType).minDebt, _newMinDebt);
+  }
+
+  function test_ModifyParameters_Collateral_SetCeilingCap() public authorized {
+    uint256 _newCeilingCap = rad(800 ether);
+    autoLiner.modifyParameters(collateralType, 'ceilingCap', abi.encode(_newCeilingCap));
+
+    assertEq(autoLiner.cParams(collateralType).ceilingCap, _newCeilingCap);
+  }
+
+  function test_ModifyParameters_Collateral_UnregisteredCollateral() public authorized {
+    autoLiner.initializeCollateralType(
+      unregisteredCollateralType,
+      abi.encode(IAutoLiner.AutoLinerCollateralParams({ceilingCap: liveDebtCeiling, minDebt: minDebt, gap: gap}))
+    );
+    autoLiner.modifyParameters(unregisteredCollateralType, 'gap', abi.encode(gap + 1));
+
+    assertEq(autoLiner.cParams(unregisteredCollateralType).gap, gap + 1);
+  }
+
+  function test_Revert_ModifyParameters_Collateral_NotInitialized() public authorized {
+    vm.expectRevert(IModifiable.UnrecognizedCType.selector);
+    autoLiner.modifyParameters(unregisteredCollateralType, 'gap', abi.encode(gap));
+  }
+
+  function test_Revert_ModifyParameters_Collateral_UnrecognizedParam() public authorized {
+    vm.expectRevert(IModifiable.UnrecognizedParam.selector);
+    autoLiner.modifyParameters(collateralType, 'invalidParam', abi.encode(gap));
+  }
+
+  function test_Revert_ModifyParameters_Collateral_NullMinDebt() public authorized {
+    vm.expectRevert(IAutoLiner.AutoLiner_NullMinDebt.selector);
+    autoLiner.modifyParameters(collateralType, 'minDebt', abi.encode(0));
+  }
+
+  function test_Revert_ModifyParameters_Collateral_NullGap() public authorized {
+    vm.expectRevert(IAutoLiner.AutoLiner_NullGap.selector);
+    autoLiner.modifyParameters(collateralType, 'gap', abi.encode(0));
+  }
+}
+
+contract Unit_AutoLiner_GetNextDebtCeiling is Base {
+  function test_Revert_NotInitializedCollateral() public {
+    vm.expectRevert(IAutoLiner.AutoLiner_CollateralTypeNotInitialized.selector);
+    autoLiner.getNextDebtCeiling(unregisteredCollateralType);
+  }
+
+  function test_Revert_SAFEEngineCollateralNotRegistered() public authorized {
+    autoLiner.initializeCollateralType(
+      unregisteredCollateralType,
+      abi.encode(IAutoLiner.AutoLinerCollateralParams({ceilingCap: liveDebtCeiling, minDebt: minDebt, gap: gap}))
+    );
+
+    vm.expectRevert(IAutoLiner.AutoLiner_CollateralTypeNotRegistered.selector);
+    autoLiner.getNextDebtCeiling(unregisteredCollateralType);
+  }
+
+  function test_Return_MinDebt_WhenDebtIs0() public {
+    assertEq(autoLiner.getNextDebtCeiling(collateralType), minDebt);
+    assertEq(autoLiner.cParams(collateralType).ceilingCap, liveDebtCeiling);
+  }
+
+  function test_Return_CurrentDebtPlusGap() public {
+    _mockCurrentDebt(collateralType, rad(100 ether));
+
+    assertEq(autoLiner.getNextDebtCeiling(collateralType), rad(150 ether));
+  }
+
+  function test_Return_CurrentDebtPlusCollateralGap() public authorized {
+    autoLiner.modifyParameters(collateralType, 'gap', abi.encode(rad(10 ether)));
+    _mockCurrentDebt(collateralType, rad(100 ether));
+
+    assertEq(autoLiner.getNextDebtCeiling(collateralType), rad(110 ether));
+  }
+
+  function test_Return_CollateralMinDebt_WhenDebtIs0() public authorized {
+    autoLiner.modifyParameters(collateralType, 'minDebt', abi.encode(rad(150 ether)));
+
+    assertEq(autoLiner.getNextDebtCeiling(collateralType), rad(150 ether));
+  }
+
+  function test_Return_Gap_WhenDebtIs0_AndGapIsAboveMinDebt() public authorized {
+    autoLiner.modifyParameters(collateralType, 'minDebt', abi.encode(rad(25 ether)));
+
+    assertEq(autoLiner.getNextDebtCeiling(collateralType), gap);
+  }
+
+  function test_Return_MinDebt_WhenCurrentDebtPlusGapIsBelowMinDebt() public authorized {
+    autoLiner.modifyParameters(collateralType, 'minDebt', abi.encode(rad(200 ether)));
+    _mockCurrentDebt(collateralType, rad(100 ether));
+
+    assertEq(autoLiner.getNextDebtCeiling(collateralType), rad(200 ether));
+  }
+
+  function test_Return_CeilingCap_WhenGapIsMaxUint() public authorized {
+    autoLiner.modifyParameters(collateralType, 'gap', abi.encode(type(uint256).max));
+    _mockCurrentDebt(collateralType, rad(100 ether));
+
+    assertEq(autoLiner.getNextDebtCeiling(collateralType), liveDebtCeiling);
+  }
+
+  function test_Return_CeilingCap_WhenCurrentDebtIsAboveCap() public authorized {
+    autoLiner.modifyParameters(collateralType, 'ceilingCap', abi.encode(rad(200 ether)));
+    _mockCurrentDebt(collateralType, rad(250 ether));
+
+    assertEq(autoLiner.getNextDebtCeiling(collateralType), rad(200 ether));
+  }
+
+  function test_Return_CeilingCap_WhenCurrentDebtPlusGapExceedsCap() public authorized {
+    autoLiner.modifyParameters(collateralType, 'ceilingCap', abi.encode(rad(140 ether)));
+    _mockCurrentDebt(collateralType, rad(100 ether));
+
+    assertEq(autoLiner.getNextDebtCeiling(collateralType), rad(140 ether));
+  }
+}
+
+contract Unit_AutoLiner_UpdateCeiling is Base {
+  function test_LowerCeiling() public {
+    _mockCurrentDebt(collateralType, rad(100 ether));
+
+    vm.expectEmit();
+    emit UpdateCeiling(collateralType, liveDebtCeiling, rad(150 ether));
+
+    uint256 _nextDebtCeiling = autoLiner.updateCeiling(collateralType);
+
+    assertEq(_nextDebtCeiling, rad(150 ether));
+    assertEq(safeEngine.cParams(collateralType).debtCeiling, rad(150 ether));
+    assertEq(autoLiner.cParams(collateralType).ceilingCap, liveDebtCeiling);
+    assertEq(autoLiner.cData(collateralType).lastUpdateTime, block.timestamp);
+  }
+
+  function test_NoOp_DoesNotUpdateLastUpdateTime() public {
+    _mockCurrentDebt(collateralType, rad(100 ether));
+    autoLiner.updateCeiling(collateralType);
+
+    uint256 _lastUpdateTime = autoLiner.cData(collateralType).lastUpdateTime;
+    vm.warp(block.timestamp + 1);
+
+    uint256 _nextDebtCeiling = autoLiner.updateCeiling(collateralType);
+
+    assertEq(_nextDebtCeiling, rad(150 ether));
+    assertEq(autoLiner.cData(collateralType).lastUpdateTime, _lastUpdateTime);
+  }
+
+  function test_Revert_Cooldown_OnIncrease() public {
+    _mockCurrentDebt(collateralType, rad(100 ether));
+    autoLiner.updateCeiling(collateralType);
+
+    _mockCurrentDebt(collateralType, rad(140 ether));
+
+    vm.expectRevert(IAutoLiner.AutoLiner_Cooldown.selector);
+    autoLiner.updateCeiling(collateralType);
+  }
+
+  function test_Revert_Cooldown_OnDecrease() public {
+    _mockCurrentDebt(collateralType, rad(100 ether));
+    autoLiner.updateCeiling(collateralType);
+
+    _mockCurrentDebt(collateralType, 0);
+
+    vm.expectRevert(IAutoLiner.AutoLiner_Cooldown.selector);
+    autoLiner.updateCeiling(collateralType);
+  }
+
+  function test_UpdateCeiling_AfterCooldown_OnIncrease() public {
+    _mockCurrentDebt(collateralType, rad(100 ether));
+    autoLiner.updateCeiling(collateralType);
+
+    _mockCurrentDebt(collateralType, rad(140 ether));
+    vm.warp(block.timestamp + cooldown);
+
+    uint256 _nextDebtCeiling = autoLiner.updateCeiling(collateralType);
+
+    assertEq(_nextDebtCeiling, rad(190 ether));
+    assertEq(safeEngine.cParams(collateralType).debtCeiling, rad(190 ether));
+  }
+
+  function test_UpdateCeiling_AfterCooldown_OnDecrease() public {
+    _mockCurrentDebt(collateralType, rad(100 ether));
+    autoLiner.updateCeiling(collateralType);
+
+    _mockCurrentDebt(collateralType, 0);
+    vm.warp(block.timestamp + cooldown);
+
+    uint256 _nextDebtCeiling = autoLiner.updateCeiling(collateralType);
+
+    assertEq(_nextDebtCeiling, minDebt);
+    assertEq(safeEngine.cParams(collateralType).debtCeiling, minDebt);
+  }
+
+  function test_UpdateCeiling_FloorToMinDebt_WhenCurrentDebtPlusGapIsBelowMinDebt() public authorized {
+    autoLiner.modifyParameters(collateralType, 'minDebt', abi.encode(rad(200 ether)));
+    _mockCurrentDebt(collateralType, rad(100 ether));
+
+    uint256 _nextDebtCeiling = autoLiner.updateCeiling(collateralType);
+
+    assertEq(_nextDebtCeiling, rad(200 ether));
+    assertEq(safeEngine.cParams(collateralType).debtCeiling, rad(200 ether));
+  }
+
+  function test_UpdateCeiling_ReturnCap_WhenGapIsMaxUint() public authorized {
+    autoLiner.modifyParameters(collateralType, 'gap', abi.encode(type(uint256).max));
+    uint256 _lowerLiveDebtCeiling = rad(300 ether);
+    safeEngine.modifyParameters(collateralType, 'debtCeiling', abi.encode(_lowerLiveDebtCeiling));
+
+    uint256 _nextDebtCeiling = autoLiner.updateCeiling(collateralType);
+
+    assertEq(_nextDebtCeiling, liveDebtCeiling);
+    assertEq(safeEngine.cParams(collateralType).debtCeiling, liveDebtCeiling);
+  }
+
+  function test_UpdateCeiling_ClampsToCap() public authorized {
+    autoLiner.modifyParameters(collateralType, 'ceilingCap', abi.encode(rad(130 ether)));
+    _mockCurrentDebt(collateralType, rad(120 ether));
+
+    uint256 _nextDebtCeiling = autoLiner.updateCeiling(collateralType);
+
+    assertEq(_nextDebtCeiling, rad(130 ether));
+    assertEq(safeEngine.cParams(collateralType).debtCeiling, rad(130 ether));
+  }
+
+  function test_UpdateCeiling_Revert_NotInitializedCollateral() public {
+    vm.expectRevert(IAutoLiner.AutoLiner_CollateralTypeNotInitialized.selector);
+    autoLiner.updateCeiling(unregisteredCollateralType);
+  }
+
+  function test_UpdateCeiling_Revert_SAFEEngineCollateralNotRegistered() public authorized {
+    autoLiner.initializeCollateralType(
+      unregisteredCollateralType,
+      abi.encode(IAutoLiner.AutoLinerCollateralParams({ceilingCap: liveDebtCeiling, minDebt: minDebt, gap: gap}))
+    );
+
+    vm.expectRevert(IAutoLiner.AutoLiner_CollateralTypeNotRegistered.selector);
+    autoLiner.updateCeiling(unregisteredCollateralType);
+  }
+
+  function test_UpdateCeiling_Revert_InactiveCollateral() public authorized {
+    autoLiner.modifyParameters(collateralType, 'ceilingCap', abi.encode(0));
+
+    vm.expectRevert(IAutoLiner.AutoLiner_CollateralTypeNotActive.selector);
+    autoLiner.updateCeiling(collateralType);
+  }
+}
+
+contract Unit_AutoLiner_InitializeCollateralType is Base {
+  function test_InitializeCollateralType_StoresParams() public authorized {
+    bytes32 _newCType = 'newCollateralType';
+    IAutoLiner.AutoLinerCollateralParams memory _params =
+      IAutoLiner.AutoLinerCollateralParams({ceilingCap: rad(500 ether), minDebt: rad(120 ether), gap: rad(25 ether)});
+
+    vm.expectEmit();
+    emit InitializeCollateralType(_newCType);
+
+    autoLiner.initializeCollateralType(_newCType, abi.encode(_params));
+
+    IAutoLiner.AutoLinerCollateralParams memory _storedParams = autoLiner.cParams(_newCType);
+    assertEq(_storedParams.ceilingCap, _params.ceilingCap);
+    assertEq(_storedParams.minDebt, _params.minDebt);
+    assertEq(_storedParams.gap, _params.gap);
+  }
+
+  function test_Revert_InitializeCollateralType_NullCeilingCap() public authorized {
+    bytes32 _newCType = 'newCollateralType';
+
+    vm.expectRevert(IAutoLiner.AutoLiner_NullCeilingCap.selector);
+    autoLiner.initializeCollateralType(
+      _newCType, abi.encode(IAutoLiner.AutoLinerCollateralParams({ceilingCap: 0, minDebt: minDebt, gap: gap}))
+    );
+  }
+
+  function test_Revert_InitializeCollateralType_NullMinDebt() public authorized {
+    bytes32 _newCType = 'newCollateralType';
+
+    vm.expectRevert(IAutoLiner.AutoLiner_NullMinDebt.selector);
+    autoLiner.initializeCollateralType(
+      _newCType, abi.encode(IAutoLiner.AutoLinerCollateralParams({ceilingCap: liveDebtCeiling, minDebt: 0, gap: gap}))
+    );
+  }
+
+  function test_Revert_InitializeCollateralType_NullGap() public authorized {
+    bytes32 _newCType = 'newCollateralType';
+
+    vm.expectRevert(IAutoLiner.AutoLiner_NullGap.selector);
+    autoLiner.initializeCollateralType(
+      _newCType,
+      abi.encode(IAutoLiner.AutoLinerCollateralParams({ceilingCap: liveDebtCeiling, minDebt: minDebt, gap: 0}))
+    );
+  }
+
+  function test_Revert_InitializeCollateralType_AlreadyInitialized() public authorized {
+    vm.expectRevert();
+    autoLiner.initializeCollateralType(
+      collateralType,
+      abi.encode(IAutoLiner.AutoLinerCollateralParams({ceilingCap: liveDebtCeiling, minDebt: minDebt, gap: gap}))
+    );
+  }
+}


### PR DESCRIPTION
# AutoLiner

  ## Summary

  This PR adds AutoLiner, a utility contract that manages per-collateral SAFEEngine.debtCeiling over time so the live ceiling tracks debt usage while respecting a  governance-defined cap, a minimum floor, and a cooldown between updates.

  The contract introduces a clean split between:

  - AutoLiner local params as the source of truth for the desired configuration
  - SAFEEngine.debtCeiling as the live enforced ceiling

  ## Motivation

  Before AutoLiner, SAFEEngine.debtCeiling was both:

  - the value governance wanted
  - the value currently enforced

  That makes dynamic headroom management awkward, because lowering the live ceiling also overwrites the long-term intended cap.

  With AutoLiner enabled for a collateral:

  - AutoLiner.ceilingCap is the desired cap
  - SAFEEngine.debtCeiling is the live execution value
  - updateCeiling(cType) reconciles the live ceiling with current debt conditions

  ## Behavior

  For an initialized and active collateral, the target ceiling is:

  min(max(minDebt, currentDebt + gap), ceilingCap)

  Special case:

  if (gap == type(uint256).max) target = ceilingCap;

  updateCeiling(cType):

  - reverts if the collateral is not initialized in AutoLiner
  - reverts if the collateral is locally deactivated (ceilingCap == 0)
  - reverts if the live SAFEEngine.debtCeiling == 0
  - no-ops if the current live ceiling already matches the target
  - otherwise enforces cooldown before updating the live ceiling in SAFEEngine

  ## Configuration Model

  ### Global params

  - cooldown

  ### Per-collateral params

  - ceilingCap
  - minDebt
  - gap

  ### Per-collateral state

  - lastUpdateTime

  ## Lifecycle

  ### Onboarding

  To enable AutoLiner for a collateral:

  1. initialize the collateral in SAFEEngine with a non-zero debtCeiling
  2. initialize the collateral in AutoLiner with non-zero:
      - ceilingCap
      - minDebt
      - gap
  3. authorize AutoLiner on SAFEEngine
  4. call updateCeiling(cType)

  ### Local deactivation

  Governance can disable AutoLiner for a collateral by setting:

  ceilingCap = 0

  This:

  - stops future AutoLiner management for that collateral
  - does not change the current live SAFEEngine.debtCeiling

  If governance wants a different live ceiling after deactivation, it must update SAFEEngine directly.

  ### SAFEEngine disable

  Setting:

  SAFEEngine.debtCeiling = 0

  blocks AutoLiner execution for that collateral, but does not erase local AutoLiner config.

  ## Implementation Notes

  - AutoLiner now uses the default ModifiablePerCollateral initialization flow
  - the init-only ceilingCap > 0 rule is enforced in _initializeCollateralType
  - per-collateral params are loaded once in _getNextDebtCeiling() for a cleaner read path
  - there are no global defaults for gap or minDebt; all active collaterals must be explicitly configured

  ## Tests

  Added and updated full coverage for:

  - constructor validation
  - global and per-collateral param changes
  - initialization requirements
  - local deactivation behavior
  - target ceiling computation
  - minDebt floor behavior
  - ceilingCap clamping
  - gap == maxUint behavior
  - cooldown enforcement on both increases and decreases
  - SAFEEngine-disabled and uninitialized collateral paths
  - end-to-end debt draw / repay flows against the full system

  ### Current results

  - forge test --match-path test/unit/AutoLiner.t.sol
  - forge test --match-path test/e2e/E2EAutoLiner.t.sol

  Result:

  - 43 unit tests passed
  - 2 e2e tests passed

  ## Docs

  The PRD was updated at:

  - docs/src/detailed/utils/autoliner.md

  It now documents:

  - the source-of-truth split between AutoLiner and SAFEEngine
  - onboarding and deactivation procedures
  - the exact target formula
  - the distinction between local deactivation and live ceiling shutdown