### PR TITLE
Update Pessimistic Velo Single Oracle

### DIFF
--- a/src/contracts/oracles/PessimisticVeloSingleOracle.sol
+++ b/src/contracts/oracles/PessimisticVeloSingleOracle.sol
@@ -313,18 +313,36 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
   }
 
   /**
-   * @notice Returns the TWAP price for a token relative to the other token in its pool.
-   * @dev Note that we can customize the length of points but we default to 4 points (2 hours). Additionally, if a
-   *  pool is very small, it may not be priced as accurately if we attempt to use 1 full token to price.
-   * @param _token The address of the token to get the price of, and that we are swapping in.
-   * @param _tokenAmount Amount of the token we are swapping in.
-   * @return twapPrice Amount of other token we get when swapping in _tokenAmount looking back over our TWAP period.
+   * @notice Returns the no-slippage TWAP quote for a token relative to the other token in its pool.
+   * @dev Samples Velodrome's stored observations like pool.quote(), but computes a marginal price from the sampled
+   *  reserves instead of simulating a finite swap through the pool curve.
+   * @param _token The address of the token to price, and that we are notionally inputting.
+   * @param _tokenAmount Amount of the token we are pricing.
+   * @return twapPrice Amount of other token implied by _tokenAmount over our TWAP period.
    */
   function getTwapPrice(address _token, uint256 _tokenAmount) public view returns (uint256 twapPrice) {
     IVeloPool poolContract = IVeloPool(pool);
 
-    // swapping one of our token gets us this many otherToken, returned in decimals of the other token
-    twapPrice = poolContract.quote(_token, _tokenAmount, points);
+    uint256 length = poolContract.observationLength() - 1;
+    uint256 i = length - points;
+
+    for (; i < length;) {
+      IVeloPool.Observation memory nextObservation = poolContract.observations(i + 1);
+      IVeloPool.Observation memory currentObservation = poolContract.observations(i);
+      uint256 timeElapsed = nextObservation.timestamp - currentObservation.timestamp;
+      uint256 reserve0Average =
+        (nextObservation.reserve0Cumulative - currentObservation.reserve0Cumulative) / timeElapsed;
+      uint256 reserve1Average =
+        (nextObservation.reserve1Cumulative - currentObservation.reserve1Cumulative) / timeElapsed;
+
+      twapPrice += _getMarginalAmountOut(_token, _tokenAmount, reserve0Average, reserve1Average);
+
+      unchecked {
+        i++;
+      }
+    }
+
+    twapPrice /= points;
   }
 
   // by default we use 0.01 tokens in this function to more accurately price small pools
@@ -434,6 +452,31 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
     }
   }
 
+  function _getMarginalAmountOut(
+    address _token,
+    uint256 _amountIn,
+    uint256 _reserve0,
+    uint256 _reserve1
+  ) internal view returns (uint256 amountOut) {
+    bool tokenInIsToken0 = _token == token0;
+
+    if (stable) {
+      uint256 normalizedReserve0 = (_reserve0 * DECIMALS) / decimals0;
+      uint256 normalizedReserve1 = (_reserve1 * DECIMALS) / decimals1;
+      (uint256 reserveA, uint256 reserveB) =
+        tokenInIsToken0 ? (normalizedReserve0, normalizedReserve1) : (normalizedReserve1, normalizedReserve0);
+      uint256 normalizedAmountIn = (_amountIn * DECIMALS) / (tokenInIsToken0 ? decimals0 : decimals1);
+      uint256 normalizedAmountOut = FixedPointMathLib.mulDivDown(
+        normalizedAmountIn, _stableDerivative(reserveB, reserveA), _stableDerivative(reserveA, reserveB)
+      );
+
+      amountOut = (normalizedAmountOut * (tokenInIsToken0 ? decimals1 : decimals0)) / DECIMALS;
+    } else {
+      (uint256 reserveA, uint256 reserveB) = tokenInIsToken0 ? (_reserve0, _reserve1) : (_reserve1, _reserve0);
+      amountOut = FixedPointMathLib.mulDivDown(_amountIn, reserveB, reserveA);
+    }
+  }
+
   // solves for cases where curve is x^3 * y + y^3 * x = k
   // fair reserves math formula author: @ksyao2002
   function _calculate_stable_lp_token_price(
@@ -471,6 +514,11 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
     uint256 newY = FixedPointMathLib.mulWadDown(y_cubed, x);
 
     return newX + newY; // 18 decimals
+  }
+
+  function _stableDerivative(uint256 x0, uint256 y) internal pure returns (uint256 derivative) {
+    derivative = 3 * FixedPointMathLib.mulWadDown(x0, FixedPointMathLib.mulWadDown(y, y))
+      + FixedPointMathLib.mulWadDown(FixedPointMathLib.mulWadDown(x0, x0), x0);
   }
 
   /* ========== SETTERS ========== */

--- a/src/contracts/oracles/PessimisticVeloSingleOracle.sol
+++ b/src/contracts/oracles/PessimisticVeloSingleOracle.sol
@@ -496,9 +496,7 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
     uint256 c = FixedPointMathLib.rpow(price0, 2, 1e18);
     uint256 d = FixedPointMathLib.rpow(price1, 2, 1e18);
 
-    uint256 p0 = k * FixedPointMathLib.mulWadDown(a, b); // 2*18 decimals
-
-    uint256 fair = p0 / (c + d); // number of decimals is 18
+    uint256 fair = FixedPointMathLib.mulDivDownFullPrecision(k, FixedPointMathLib.mulWadDown(a, b), c + d);
 
     // each sqrt divides the num decimals by 2. So need to replenish the decimals midway through with another 1e18
     uint256 frth_fair = FixedPointMathLib.sqrt(FixedPointMathLib.sqrt(fair * 1e18) * 1e18); // number of decimals is 18

--- a/src/interfaces/external/IVeloPool.sol
+++ b/src/interfaces/external/IVeloPool.sol
@@ -4,6 +4,12 @@ pragma solidity 0.8.20;
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 
 interface IVeloPool is IERC20 {
+  struct Observation {
+    uint256 timestamp;
+    uint256 reserve0Cumulative;
+    uint256 reserve1Cumulative;
+  }
+
   /**
    * @notice Returns the value of tokens in existence.
    */
@@ -20,6 +26,10 @@ interface IVeloPool is IERC20 {
   function symbol() external view returns (string memory _symbol);
 
   function quote(address tokenIn, uint256 amountIn, uint256 granularity) external view returns (uint256);
+
+  function observationLength() external view returns (uint256);
+
+  function observations(uint256 index) external view returns (Observation memory);
 
   function getReserves() external view returns (uint256 _reserve0, uint256 _reserve1, uint256 _blockTimestampLast);
 

--- a/src/libraries/FixedPointMathLib.sol
+++ b/src/libraries/FixedPointMathLib.sol
@@ -56,6 +56,47 @@ library FixedPointMathLib {
     }
   }
 
+  /// @notice Calculates floor(x * y / denominator) with full precision.
+  /// @dev Adapted from Uniswap V3 FullMath.mulDiv.
+  function mulDivDownFullPrecision(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 z) {
+    /// @solidity memory-safe-assembly
+    assembly {
+      let mm := mulmod(x, y, not(0))
+      let prod0 := mul(x, y)
+      let prod1 := sub(sub(mm, prod0), lt(mm, prod0))
+
+      switch prod1
+      case 0 {
+        if iszero(denominator) { revert(0, 0) }
+        z := div(prod0, denominator)
+      }
+      default {
+        if iszero(gt(denominator, prod1)) { revert(0, 0) }
+
+        let remainder := mulmod(x, y, denominator)
+        prod1 := sub(prod1, gt(remainder, prod0))
+        prod0 := sub(prod0, remainder)
+
+        let twos := and(denominator, sub(0, denominator))
+        denominator := div(denominator, twos)
+        prod0 := div(prod0, twos)
+
+        twos := add(div(sub(0, twos), twos), 1)
+        prod0 := or(prod0, mul(prod1, twos))
+
+        let inverse := xor(mul(3, denominator), 2)
+        inverse := mul(inverse, sub(2, mul(denominator, inverse)))
+        inverse := mul(inverse, sub(2, mul(denominator, inverse)))
+        inverse := mul(inverse, sub(2, mul(denominator, inverse)))
+        inverse := mul(inverse, sub(2, mul(denominator, inverse)))
+        inverse := mul(inverse, sub(2, mul(denominator, inverse)))
+        inverse := mul(inverse, sub(2, mul(denominator, inverse)))
+
+        z := mul(prod0, inverse)
+      }
+    }
+  }
+
   function rpow(uint256 x, uint256 n, uint256 scalar) internal pure returns (uint256 z) {
     /// @solidity memory-safe-assembly
     assembly {

--- a/test/unit/oracles/PessimisticVeloSingleOracle.t.sol
+++ b/test/unit/oracles/PessimisticVeloSingleOracle.t.sol
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.20;
+
+import {PessimisticVeloSingleOracle} from '@contracts/oracles/PessimisticVeloSingleOracle.sol';
+import {IVeloPool} from '@interfaces/external/IVeloPool.sol';
+import {IChainlinkOracle} from '@interfaces/oracles/IChainlinkOracle.sol';
+import {HaiTest} from '@test/utils/HaiTest.t.sol';
+
+contract ChainlinkOracleForTest is IChainlinkOracle {
+  uint8 internal immutable _decimals;
+  int256 internal _answer;
+  uint256 internal _updatedAt;
+
+  constructor(uint8 __decimals, int256 __answer, uint256 __updatedAt) {
+    _decimals = __decimals;
+    _answer = __answer;
+    _updatedAt = __updatedAt;
+  }
+
+  function decimals() external view returns (uint8 __decimals) {
+    return _decimals;
+  }
+
+  function description() external pure returns (string memory _description) {
+    return 'ChainlinkOracleForTest';
+  }
+
+  function getAnswer(uint256) external view returns (int256 _latestAnswer) {
+    return _answer;
+  }
+
+  function getRoundData(uint256)
+    external
+    view
+    returns (uint256 _roundId, int256 __answer, uint256 _startedAt, uint256 __updatedAt, uint256 _answeredInRound)
+  {
+    return (1, _answer, _updatedAt, _updatedAt, 1);
+  }
+
+  function getTimestamp(uint256) external view returns (uint256 _timestamp) {
+    return _updatedAt;
+  }
+
+  function latestAnswer() external view returns (int256 _latestAnswer) {
+    return _answer;
+  }
+
+  function latestRound() external pure returns (uint256 _latestRound) {
+    return 1;
+  }
+
+  function latestRoundData()
+    external
+    view
+    returns (uint256 _roundId, int256 __answer, uint256 _startedAt, uint256 __updatedAt, uint256 _answeredInRound)
+  {
+    return (1, _answer, _updatedAt, _updatedAt, 1);
+  }
+
+  function latestTimestamp() external view returns (uint256 _latestTimestamp) {
+    return _updatedAt;
+  }
+}
+
+contract VeloPoolForTest is IVeloPool {
+  error QuoteShouldNotBeCalled();
+
+  string public name = 'VeloPoolForTest';
+  string public symbol = 'VPT';
+  uint8 public decimals = 18;
+  uint256 public totalSupply = 1e18;
+  uint256 public reserve0;
+  uint256 public reserve1;
+  bool public stable;
+  address public token0;
+  address public token1;
+  uint256 internal _decimals0;
+  uint256 internal _decimals1;
+  Observation[] internal _observations;
+
+  constructor(address _token0, address _token1, bool _stable, uint256 __decimals0, uint256 __decimals1) {
+    token0 = _token0;
+    token1 = _token1;
+    stable = _stable;
+    _decimals0 = __decimals0;
+    _decimals1 = __decimals1;
+  }
+
+  function setConstantObservations(uint256 _reserve0, uint256 _reserve1, uint256 _observationCount) external {
+    delete _observations;
+    reserve0 = _reserve0;
+    reserve1 = _reserve1;
+
+    for (uint256 i = 0; i < _observationCount;) {
+      uint256 timestamp = i + 1;
+      _observations.push(
+        Observation({
+          timestamp: timestamp,
+          reserve0Cumulative: _reserve0 * timestamp,
+          reserve1Cumulative: _reserve1 * timestamp
+        })
+      );
+
+      unchecked {
+        i++;
+      }
+    }
+  }
+
+  function balanceOf(address) external pure returns (uint256 _balance) {
+    return 0;
+  }
+
+  function transfer(address, uint256) external pure returns (bool _success) {
+    return true;
+  }
+
+  function allowance(address, address) external pure returns (uint256 _allowance) {
+    return 0;
+  }
+
+  function approve(address, uint256) external pure returns (bool _success) {
+    return true;
+  }
+
+  function transferFrom(address, address, uint256) external pure returns (bool _success) {
+    return true;
+  }
+
+  function quote(address, uint256, uint256) external pure returns (uint256) {
+    revert QuoteShouldNotBeCalled();
+  }
+
+  function observationLength() external view returns (uint256 _observationLength) {
+    return _observations.length;
+  }
+
+  function observations(uint256 index) external view returns (Observation memory _observation) {
+    return _observations[index];
+  }
+
+  function getReserves() external view returns (uint256 _reserve0, uint256 _reserve1, uint256 _blockTimestampLast) {
+    return (reserve0, reserve1, block.timestamp);
+  }
+
+  function metadata()
+    external
+    view
+    returns (uint256 dec0, uint256 dec1, uint256 r0, uint256 r1, bool st, address t0, address t1)
+  {
+    return (_decimals0, _decimals1, reserve0, reserve1, stable, token0, token1);
+  }
+}
+
+abstract contract PessimisticVeloSingleOracleTest is HaiTest {
+  address internal constant SEQUENCER_UPTIME_FEED = 0x371EAD81c9102C9BF4874A9075FFFf170F2Ee389;
+  address internal token0 = label('token0');
+  address internal token1 = label('token1');
+  uint256 internal constant POINTS = 4;
+
+  ChainlinkOracleForTest internal token0Feed;
+  VeloPoolForTest internal pool;
+  PessimisticVeloSingleOracle internal oracle;
+
+  function _deployOracle(bool _stable, uint256 _reserve0, uint256 _reserve1) internal {
+    _deployOracle(_stable, 1e18, 1e18, _reserve0, _reserve1);
+  }
+
+  function _deployOracle(
+    bool _stable,
+    uint256 _decimals0,
+    uint256 _decimals1,
+    uint256 _reserve0,
+    uint256 _reserve1
+  ) internal {
+    token0Feed = new ChainlinkOracleForTest(8, 200_000_000, block.timestamp);
+    pool = new VeloPoolForTest(token0, token1, _stable, _decimals0, _decimals1);
+    pool.setConstantObservations(_reserve0, _reserve1, POINTS + 1);
+    oracle =
+      new PessimisticVeloSingleOracle(address(pool), address(token0Feed), address(0), 3600, 3600, POINTS, address(this));
+  }
+
+  function _mockSequencerUp() internal {
+    vm.mockCall(
+      SEQUENCER_UPTIME_FEED,
+      abi.encodeCall(IChainlinkOracle.latestRoundData, ()),
+      abi.encode(uint256(1), int256(0), block.timestamp - 2 hours, block.timestamp - 2 hours, uint256(1))
+    );
+  }
+
+  function _stableDerivative(uint256 x0, uint256 y) internal pure returns (uint256 derivative) {
+    derivative = 3 * ((x0 * ((y * y) / 1e18)) / 1e18) + ((((x0 * x0) / 1e18) * x0) / 1e18);
+  }
+}
+
+contract Unit_PessimisticVeloSingleOracle_GetTwapPrice is PessimisticVeloSingleOracleTest {
+  function test_Volatile_ReturnsNoSlippageMarginalPrice() public {
+    _deployOracle(false, 100e18, 200e18);
+
+    assertEq(oracle.getTwapPrice(token0, 1e18), 2e18);
+    assertEq(oracle.getTwapPrice(token0, 100e18), 200e18);
+    assertEq(oracle.getTwapPrice(token1, 1e18), 0.5e18);
+    assertEq(oracle.getTwapPrice(token1, 100e18), 50e18);
+  }
+
+  function test_Stable_ReturnsNoSlippageMarginalPrice() public {
+    _deployOracle(true, 100e18, 200e18);
+
+    uint256 expectedToken0ToToken1 = (1e18 * _stableDerivative(200e18, 100e18)) / _stableDerivative(100e18, 200e18);
+    uint256 expectedToken1ToToken0 = (1e18 * _stableDerivative(100e18, 200e18)) / _stableDerivative(200e18, 100e18);
+
+    assertEq(oracle.getTwapPrice(token0, 1e18), expectedToken0ToToken1);
+    assertEq(oracle.getTwapPrice(token1, 1e18), expectedToken1ToToken0);
+    assertApproxEqAbs(oracle.getTwapPrice(token0, 100e18), expectedToken0ToToken1 * 100, 100);
+    assertApproxEqAbs(oracle.getTwapPrice(token1, 100e18), expectedToken1ToToken0 * 100, 100);
+  }
+
+  function test_Stable_HandlesDifferentTokenDecimals() public {
+    _deployOracle(true, 1e6, 1e18, 1000e6, 2000e18);
+
+    uint256 expectedToken0ToToken1 = (1e18 * _stableDerivative(2000e18, 1000e18)) / _stableDerivative(1000e18, 2000e18);
+
+    assertEq(oracle.getTwapPrice(token0, 1e6), expectedToken0ToToken1);
+    assertApproxEqAbs(oracle.getTwapPrice(token0, 100e6), expectedToken0ToToken1 * 100, 100);
+  }
+
+  function test_GetTokenPrices_UsesNoSlippageTwapPrice() public {
+    _deployOracle(false, 100e18, 200e18);
+    _mockSequencerUp();
+
+    (uint256 price0, uint256 price1) = oracle.getTokenPrices();
+
+    assertEq(price0, 200_000_000);
+    assertEq(price1, 100_000_000);
+  }
+}

--- a/test/unit/oracles/PessimisticVeloSingleOracle.t.sol
+++ b/test/unit/oracles/PessimisticVeloSingleOracle.t.sol
@@ -159,6 +159,7 @@ abstract contract PessimisticVeloSingleOracleTest is HaiTest {
   uint256 internal constant POINTS = 4;
 
   ChainlinkOracleForTest internal token0Feed;
+  ChainlinkOracleForTest internal token1Feed;
   VeloPoolForTest internal pool;
   PessimisticVeloSingleOracle internal oracle;
 
@@ -178,6 +179,22 @@ abstract contract PessimisticVeloSingleOracleTest is HaiTest {
     pool.setConstantObservations(_reserve0, _reserve1, POINTS + 1);
     oracle =
       new PessimisticVeloSingleOracle(address(pool), address(token0Feed), address(0), 3600, 3600, POINTS, address(this));
+  }
+
+  function _deployOracleWithFeeds(
+    bool _stable,
+    uint256 _reserve0,
+    uint256 _reserve1,
+    int256 _price0,
+    int256 _price1
+  ) internal {
+    token0Feed = new ChainlinkOracleForTest(8, _price0, block.timestamp);
+    token1Feed = new ChainlinkOracleForTest(8, _price1, block.timestamp);
+    pool = new VeloPoolForTest(token0, token1, _stable, 1e18, 1e18);
+    pool.setConstantObservations(_reserve0, _reserve1, POINTS + 1);
+    oracle = new PessimisticVeloSingleOracle(
+      address(pool), address(token0Feed), address(token1Feed), 3600, 3600, POINTS, address(this)
+    );
   }
 
   function _mockSequencerUp() internal {
@@ -232,5 +249,12 @@ contract Unit_PessimisticVeloSingleOracle_GetTwapPrice is PessimisticVeloSingleO
 
     assertEq(price0, 200_000_000);
     assertEq(price1, 100_000_000);
+  }
+
+  function test_StableLpPrice_DoesNotOverflowForDeepHighPricedPool() public {
+    _deployOracleWithFeeds(true, 100_000e18, 100_000e18, 3000e8, 3000e8);
+    _mockSequencerUp();
+
+    assertGt(oracle.getCurrentPoolPrice(false), 0);
   }
 }


### PR DESCRIPTION
 ## Summary

  - Replace `PessimisticVeloSingleOracle`'s use of `pool.quote()` with direct
  Velodrome observation sampling.
  - Compute no-slippage marginal TWAP prices from sampled average reserves.
  - Add volatile, stable, mixed-decimal, and `getTokenPrices()` coverage for
  the new TWAP path.

  ## Details

  Velodrome/Aerodrome `quote()` averages finite swap outputs from TWAP-sampled
  reserves, so the result is amount-sensitive and includes price impact. This
  oracle uses the TWAP path as a price input, so it should use the marginal
  reserve-implied price instead.

  The new implementation reads pool observations directly, derives average
  reserves over each sampled window, then computes:

  - volatile pools: `amountIn * reserveOut / reserveIn`
  - stable pools: derivative-based marginal price for `x^3y + y^3x = k`

  ## Testing

  - `forge test --match-path test/unit/oracles/
  PessimisticVeloSingleOracle.t.sol -vvv`
  - `forge build`
  - `git diff --check`