### PR TITLE
feat: pessimistic Velo single oracle — v1 review + v2 review fixes

### DIFF
--- a/src/contracts/CollateralAuctionHouse.sol
+++ b/src/contracts/CollateralAuctionHouse.sol
@@ -134,6 +134,8 @@ contract CollateralAuctionHouse is Authorizable, Modifiable, Disableable, IColla
 
   /**
    * @notice Get the collateral price from the oracle
+   * @dev Uses the collateral oracle configured in OracleRelayer for both SAFE accounting and auction execution.
+   *      For Velo LP collateral this intentionally means auctions use the same delayed/pessimistic price source.
    * @return _collateralPrice The collateral price if valid [wad]
    */
   function _getCollateralPrice() internal view returns (uint256 _collateralPrice) {

--- a/src/contracts/jobs/OracleJob.sol
+++ b/src/contracts/jobs/OracleJob.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.20;
 
 import {IOracleJob} from '@interfaces/jobs/IOracleJob.sol';
 import {IOracleRelayer} from '@interfaces/IOracleRelayer.sol';
+import {IAbstractVeloVaultRelayer} from '@interfaces/oracles/IAbstractVeloVaultRelayer.sol';
 import {IDelayedOracle} from '@interfaces/oracles/IDelayedOracle.sol';
 import {IPIDRateSetter} from '@interfaces/IPIDRateSetter.sol';
 
@@ -64,7 +65,21 @@ contract OracleJob is Authorizable, Modifiable, Job, IOracleJob {
     if (!shouldWorkUpdateCollateralPrice) revert NotWorkable();
 
     IDelayedOracle _delayedOracle = IDelayedOracle(address(oracleRelayer.cParams(_cType).oracle));
-    if (!_delayedOracle.updateResult()) revert OracleJob_InvalidPrice();
+    (bool _success, bytes memory _returnData) =
+      address(_delayedOracle).staticcall(abi.encodeCall(IDelayedOracle.priceSource, ()));
+    if (_success && _returnData.length >= 32) {
+      address _priceSource = abi.decode(_returnData, (address));
+      address(_priceSource).call(abi.encodeCall(IAbstractVeloVaultRelayer.updatePricePerFullShare, ()));
+    }
+    // Propagate the delayed oracle's result on every genuine state transition, including an invalidation, so a
+    // fail-closed price reaches the SAFE engine via the rewarded keeper path instead of lingering as a stale
+    // value (DelayedOracle has no staleness expiry). Only a true no-op -- updateResult() returning false WITHOUT
+    // advancing lastUpdateTime -- is rejected, so keepers cannot farm rewards on repeated invalid reads.
+    // (Escalation option, if transient outages prove disruptive: gate propagation on N consecutive invalid cycles.)
+    uint256 _lastUpdateTimeBefore = _delayedOracle.lastUpdateTime();
+    if (!_delayedOracle.updateResult() && _delayedOracle.lastUpdateTime() == _lastUpdateTimeBefore) {
+      revert OracleJob_InvalidPrice();
+    }
 
     oracleRelayer.updateCollateralPrice(_cType);
   }

--- a/src/contracts/oracles/AbstractVeloVaultRelayer.sol
+++ b/src/contracts/oracles/AbstractVeloVaultRelayer.sol
@@ -5,14 +5,18 @@ import {IBaseOracle} from '@interfaces/oracles/IBaseOracle.sol';
 import {IAbstractVeloVaultRelayer} from '@interfaces/oracles/IAbstractVeloVaultRelayer.sol';
 import {IVeloPool} from '@interfaces/external/IVeloPool.sol';
 import {IPessimisticVeloLpOracle} from '@interfaces/external/IPessimisticVeloLpOracle.sol';
-import {Math, WAD} from '@libraries/Math.sol';
 
 /**
  * @title  AbstractVeloVaultRelayer
  * @notice Abstract contract for Velo vault relayers (Beefy, Yearn, etc.)
  */
 abstract contract AbstractVeloVaultRelayer is IAbstractVeloVaultRelayer {
-  using Math for uint256;
+  // --- Constants ---
+
+  uint256 internal constant _BPS = 10_000;
+  uint256 public constant PRICE_PER_FULL_SHARE_UPDATE_DELAY = 1 hours;
+  uint256 public constant MAX_PRICE_PER_FULL_SHARE_INCREASE_BPS = 100;
+
   // --- Registry ---
 
   /// @inheritdoc IAbstractVeloVaultRelayer
@@ -25,6 +29,12 @@ abstract contract AbstractVeloVaultRelayer is IAbstractVeloVaultRelayer {
 
   /// @inheritdoc IBaseOracle
   string public symbol;
+
+  /// @inheritdoc IAbstractVeloVaultRelayer
+  uint256 public acceptedPricePerFullShare;
+
+  /// @inheritdoc IAbstractVeloVaultRelayer
+  uint256 public lastPricePerFullShareUpdateTime;
 
   // --- Init ---
 
@@ -49,35 +59,122 @@ abstract contract AbstractVeloVaultRelayer is IAbstractVeloVaultRelayer {
   }
 
   /// @inheritdoc IBaseOracle
-  /// @notice This function always returns `_validity` as `true` since there are no conditions where the result would be invalid.
   function getResultWithValidity() external view returns (uint256 _result, bool _validity) {
-    uint256 _totalValue = _getPriceValue();
+    try veloLpOracle.getCurrentPoolPrice(true) returns (uint256 _veloLpPrice) {
+      if (_veloLpPrice == 0) return (0, false);
 
-    return (_totalValue, true);
+      _result = _calculatePriceValue(_veloLpPrice);
+      _validity = _result > 0;
+    } catch {
+      return (0, false);
+    }
   }
   /// @inheritdoc IBaseOracle
 
   function read() external view returns (uint256 _result) {
-    return _getPriceValue();
+    return _getPriceValue(veloLpOracle.getCurrentPoolPrice(true));
   }
 
-  function _getPriceValue() internal view returns (uint256 _combinedPriceValue) {
-    // 1 yvToken or mooToken
-    uint256 _baseTokenBalance = 1_000_000_000_000_000_000;
+  /// @inheritdoc IAbstractVeloVaultRelayer
+  function updatePricePerFullShare() external returns (bool _updated) {
+    return _updatePricePerFullShare();
+  }
 
-    // # of velo LP tokens in 1 yvToken
-    uint256 _veloLpBalance = _baseTokenBalance.wmul(_getPricePerFullShare());
+  /// @inheritdoc IAbstractVeloVaultRelayer
+  function livePricePerFullShare() external view returns (uint256 _pricePerFullShare) {
+    return _getPricePerFullShare();
+  }
 
-    // price of 1 velo LP token in chainlink price decimals (8)
-    uint256 _veloLpPrice = veloLpOracle.getCurrentPoolPrice(true);
-
-    uint256 _price = (_veloLpBalance * _veloLpPrice) / 1e8;
+  function _getPriceValue(uint256 _veloLpPrice) internal view returns (uint256 _combinedPriceValue) {
+    uint256 _price = _calculatePriceValue(_veloLpPrice);
 
     if (_price == 0) {
       revert AbstractVeloVaultRelayer_ZeroPrice();
     }
 
     return _price;
+  }
+
+  function _calculatePriceValue(uint256 _veloLpPrice) internal view returns (uint256 _price) {
+    // # of velo LP tokens in 1 yvToken. Use the lower of the cached and live price-per-full-share so vault
+    // losses are reflected immediately, without waiting for an updatePricePerFullShare() call. The live read
+    // is an external vault call wrapped in try/catch; on failure we fail closed (return 0) instead of falling
+    // back to the cached value, which could otherwise re-enable a stale-high price.
+    uint256 _veloLpBalance = acceptedPricePerFullShare;
+    try this.livePricePerFullShare() returns (uint256 _livePricePerFullShare) {
+      if (_livePricePerFullShare < _veloLpBalance) {
+        _veloLpBalance = _livePricePerFullShare;
+      }
+    } catch {
+      return 0;
+    }
+
+    if (_veloLpPrice != 0 && _veloLpBalance > type(uint256).max / _veloLpPrice) {
+      return 0;
+    }
+
+    _price = (_veloLpBalance * _veloLpPrice) / 1e8;
+  }
+
+  function _initializePricePerFullShare() internal {
+    uint256 _pricePerFullShare = _getPricePerFullShare();
+    if (_pricePerFullShare == 0) {
+      revert AbstractVeloVaultRelayer_InvalidPricePerFullShare();
+    }
+
+    acceptedPricePerFullShare = _pricePerFullShare;
+    lastPricePerFullShareUpdateTime = block.timestamp;
+
+    emit UpdatePricePerFullShare(_pricePerFullShare);
+  }
+
+  function _updatePricePerFullShare() internal returns (bool _updated) {
+    uint256 _pricePerFullShare = _getPricePerFullShare();
+    uint256 _acceptedPricePerFullShare = acceptedPricePerFullShare;
+
+    if (_pricePerFullShare == 0) {
+      acceptedPricePerFullShare = 0;
+      lastPricePerFullShareUpdateTime = block.timestamp;
+
+      emit UpdatePricePerFullShare(0);
+
+      return true;
+    }
+
+    if (_acceptedPricePerFullShare == 0) {
+      acceptedPricePerFullShare = _pricePerFullShare;
+      lastPricePerFullShareUpdateTime = block.timestamp;
+
+      emit UpdatePricePerFullShare(_pricePerFullShare);
+
+      return true;
+    }
+
+    // No-op when the live price equals the accepted price: do not touch the update timestamp, otherwise a
+    // permissionless no-op call during a flat-price window would defer the next allowed upward move by up to
+    // PRICE_PER_FULL_SHARE_UPDATE_DELAY. Placed after the zero branches so their invalidation semantics hold.
+    if (_pricePerFullShare == _acceptedPricePerFullShare) {
+      return false;
+    }
+
+    if (_pricePerFullShare > _acceptedPricePerFullShare) {
+      if (block.timestamp < lastPricePerFullShareUpdateTime + PRICE_PER_FULL_SHARE_UPDATE_DELAY) {
+        return false;
+      }
+
+      uint256 _maxPricePerFullShare =
+        (_acceptedPricePerFullShare * (_BPS + MAX_PRICE_PER_FULL_SHARE_INCREASE_BPS)) / _BPS;
+      if (_pricePerFullShare > _maxPricePerFullShare) {
+        _pricePerFullShare = _maxPricePerFullShare;
+      }
+    }
+
+    acceptedPricePerFullShare = _pricePerFullShare;
+    lastPricePerFullShareUpdateTime = block.timestamp;
+
+    emit UpdatePricePerFullShare(_pricePerFullShare);
+
+    return true;
   }
 
   /// @notice Virtual function to be implemented by child contracts

--- a/src/contracts/oracles/BeefyVeloVaultRelayer.sol
+++ b/src/contracts/oracles/BeefyVeloVaultRelayer.sol
@@ -43,6 +43,7 @@ contract BeefyVeloVaultRelayer is AbstractVeloVaultRelayer, IBeefyVeloVaultRelay
     }
 
     beefyVault = _beefyVault;
+    _initializePricePerFullShare();
   }
 
   function _getPricePerFullShare() internal view override returns (uint256 _pricePerFullShare) {

--- a/src/contracts/oracles/PessimisticVeloSingleOracle.sol
+++ b/src/contracts/oracles/PessimisticVeloSingleOracle.sol
@@ -569,18 +569,32 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
 
     if (stable) {
       _validateStablePriceDeviation(price0, price1);
-      fairReservesPricing = _calculate_stable_lp_token_price(totalSupply, price0, price1, reserve0, reserve1, 8);
-    } else {
-      uint256 k = _getVolatileGeometricMean(reserve0, reserve1); // xy = k, p0r0' = p1r1', this is in 1e18
-      uint256 p = FixedPointMathLib.sqrt(price0 * 1e16 * price1); // boost this to 1e16 to give us more precision
-
-      // we want k and total supply to have same number of decimals so price has decimals of chainlink oracle
-      fairReservesPricing = FixedPointMathLib.mulDivDownFullPrecision(2 * p, k, totalSupply) / 1e8;
     }
+    fairReservesPricing = _fairReservesValue(totalSupply, price0, price1, reserve0, reserve1);
 
     // for single-feed pools (volatile or stable), bound the LP price by the value of the trusted (fed) side.
     // no-op for dual-feed pools.
     fairReservesPricing = _capSingleFeedPrice(fairReservesPricing, totalSupply, price0, price1);
+  }
+
+  // fair-reserves LP value for the given reserves/prices/supply (manipulation-resistant: stable uses the
+  // x^3y+y^3x invariant, volatile uses the geometric mean k), in chainlink (8-decimal) units
+  function _fairReservesValue(
+    uint256 _totalSupply,
+    uint256 _price0,
+    uint256 _price1,
+    uint256 _reserve0,
+    uint256 _reserve1
+  ) internal view returns (uint256 _fairValue) {
+    if (stable) {
+      _fairValue = _calculate_stable_lp_token_price(_totalSupply, _price0, _price1, _reserve0, _reserve1, 8);
+    } else {
+      uint256 k = _getVolatileGeometricMean(_reserve0, _reserve1); // xy = k, p0r0' = p1r1', this is in 1e18
+      uint256 p = FixedPointMathLib.sqrt(_price0 * 1e16 * _price1); // boost this to 1e16 to give us more precision
+
+      // we want k and total supply to have same number of decimals so price has decimals of chainlink oracle
+      _fairValue = FixedPointMathLib.mulDivDownFullPrecision(2 * p, k, _totalSupply) / 1e8;
+    }
   }
 
   function _capSingleFeedPrice(
@@ -592,22 +606,25 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
     cappedPrice = _lpPrice;
     if (!_isSingleFeed()) return cappedPrice;
 
-    // Bound the LP price by twice the value of the trusted (fed) side, using TWAP-averaged reserves so the
-    // bound cannot be moved by a single-block reserve manipulation (a spot drain/inflation no longer collapses
-    // or inflates the cached low). For stable pools the bound roughly equals fair value at balance, so it will
-    // bind -- and conservatively underprice by ~the imbalance fraction -- during a sustained imbalance toward
-    // the unfed side. That pessimistic-direction cost is the accepted price of resisting unfed-token depeg
-    // overvaluation, where the trusted reserve drains while the TWAP-derived unfed price still lags near peg.
+    // Bound the LP price by twice the value of the trusted (fed) side. Both the trusted-side bound and the fair
+    // value it is compared against are computed from the same TWAP-averaged reserves and the same totalSupply,
+    // so a single-block reserve OR totalSupply change (e.g. a flash mint/burn that would otherwise mismatch
+    // TWAP reserves with spot supply) cannot move the bound -- the supply cancels in the ratio below. The spot
+    // fair price is then scaled by that supply-independent fraction, which still tracks a sustained drain of
+    // the trusted reserve (the unfed-token depeg case) while staying invariant to liquidity-supply manipulation.
     (uint256 reserve0Average, uint256 reserve1Average) = _getTwapAverageReserves();
 
-    uint256 cap;
+    uint256 trustedValue;
     if (token0Feed != address(0)) {
-      cap = 2 * FixedPointMathLib.mulDivDownFullPrecision(reserve0Average, _price0, _totalSupply);
+      trustedValue = 2 * FixedPointMathLib.mulDivDownFullPrecision(reserve0Average, _price0, _totalSupply);
     } else {
-      cap = 2 * FixedPointMathLib.mulDivDownFullPrecision(reserve1Average, _price1, _totalSupply);
+      trustedValue = 2 * FixedPointMathLib.mulDivDownFullPrecision(reserve1Average, _price1, _totalSupply);
     }
 
-    if (_lpPrice > cap) cappedPrice = cap;
+    uint256 fairValueTwap = _fairReservesValue(_totalSupply, _price0, _price1, reserve0Average, reserve1Average);
+    if (fairValueTwap == 0 || trustedValue >= fairValueTwap) return cappedPrice;
+
+    cappedPrice = FixedPointMathLib.mulDivDownFullPrecision(_lpPrice, trustedValue, fairValueTwap);
   }
 
   // average of the per-interval TWAP reserves over the configured window, normalized to 18 decimals

--- a/src/contracts/oracles/PessimisticVeloSingleOracle.sol
+++ b/src/contracts/oracles/PessimisticVeloSingleOracle.sol
@@ -38,6 +38,20 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
   /// @notice Number of times our token's price was checked on a given day.
   mapping(uint256 => uint256) public dailyUpdates; // day => number of updates
 
+  /// @notice Last time the daily low state was updated from live pricing.
+  uint256 public lastPriceUpdateTime;
+
+  /// @notice Day of the most recently recorded daily low. Source of the single-feed clamp carry-in anchor.
+  uint256 public lastValidLowDay;
+
+  /// @notice Day for which the single-feed daily-low floor is currently frozen.
+  /// @dev Internal bookkeeping for the volatile single-feed fail-soft clamp.
+  uint256 internal clampFloorDay;
+
+  /// @notice Frozen minimum daily low for the current day on volatile single-feed pools.
+  /// @dev All of a day's recorded lows are clamped to this floor, so the bound cannot ratchet intra-day.
+  uint256 internal clampFloor;
+
   /// @notice Whether we use a three-day low instead of a two-day low.
   /// @dev May only be updated by owner. Realistically most useful when price updating is public, as this
   ///  guarantees any price observations used must be at least 24 hours apart.
@@ -46,6 +60,17 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
   /// @notice Custom number of periods our TWAP price should cover.
   /// @dev Set on deployment, minimum is 4 (2 hours).
   uint256 public immutable points;
+
+  /// @notice Maximum age/gap allowed for Velodrome TWAP observations.
+  /// @dev Set on deployment to allow pool-specific liveness/security tradeoffs.
+  uint256 public immutable maxTwapObservationInterval;
+
+  /// @notice Maximum token price ratio allowed for stable Velodrome pool pricing.
+  /// @dev 18-decimal ratio where 1e18 means 1:1.
+  uint256 public immutable maxStablePriceDeviation;
+
+  /// @notice Maximum age allowed for the latest successful pessimistic price update.
+  uint256 public immutable maxPessimisticPriceAge;
 
   /// @notice Chainlink feed to check that Optimism's sequencer is online.
   /// @dev This prevents transactions sent while the sequencer is down from being executed when it comes back online.
@@ -93,6 +118,30 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
   // our pool/LP token decimals, just in case velodrome has weird pools in the future with different decimals
   uint256 internal constant DECIMALS = 10 ** 18;
 
+  /// @notice Velodrome observations are normally recorded after this period elapses.
+  uint256 internal constant VELO_OBSERVATION_PERIOD = 30 minutes;
+
+  /// @notice Maximum scaled reserve or reserve-value root used in stable LP fourth-power math.
+  uint256 internal constant STABLE_LP_PRICING_SCALE_LIMIT = 1e27;
+
+  /// @notice Maximum normalized reserve size used when computing stable TWAP derivative ratios.
+  uint256 internal constant STABLE_DERIVATIVE_SCALE_LIMIT = 1e27;
+
+  /// @notice Maximum normalized reserve size used before volatile geometric-mean scaling.
+  uint256 internal constant VOLATILE_GEOMEAN_SCALE_LIMIT = 1e27;
+
+  /// @notice Maximum token price ratio allowed for stable-pool collateral pricing.
+  uint256 internal constant MAX_STABLE_PRICE_DEVIATION = 1.05e18;
+
+  /// @notice Maximum daily-low decrease allowed for volatile single-feed pools.
+  uint256 internal constant MAX_SINGLE_FEED_DAILY_LOW_DECREASE_BPS = 2000;
+
+  /// @notice Maximum number of elapsed days the single-feed daily-low floor decays over after a keeper gap.
+  /// @dev Caps the compounding so a long outage cannot erase the floor entirely on the first update back.
+  uint256 internal constant MAX_SINGLE_FEED_LOW_DECAY_DAYS = 3;
+
+  uint256 internal constant BPS = 10_000;
+
   /* ========== CONSTRUCTOR ========== */
   /**
    * @dev Check Chainlink's documentation for heartbeat length of their various feeds.
@@ -102,6 +151,9 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
    * @param _token0Heartbeat The heartbeat for our token0 feed (maximum time allowed before refresh).
    * @param _token1Heartbeat The heartbeat for our token1 feed (maximum time allowed before refresh).
    * @param _twapPoints Number of samples for TWAP pricing. Minimum is 4 (2 hours).
+   * @param _maxTwapObservationInterval Maximum allowed age/gap for sampled Velodrome TWAP observations.
+   * @param _maxStablePriceDeviation Maximum token price ratio allowed when pricing stable pools.
+   * @param _maxPessimisticPriceAge Maximum age allowed for cached pessimistic pricing.
    * @param _owner Owner role. Can set operators and adjust 2 vs 3 day pessimistic pricing.
    */
   constructor(
@@ -111,6 +163,9 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
     uint96 _token0Heartbeat,
     uint96 _token1Heartbeat,
     uint256 _twapPoints,
+    uint256 _maxTwapObservationInterval,
+    uint256 _maxStablePriceDeviation,
+    uint256 _maxPessimisticPriceAge,
     address _owner
   ) Ownable(_owner) {
     // The default number of periods (points) we look back in time for TWAP pricing.
@@ -119,6 +174,24 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
       revert TooFewTwapPoints();
     }
     points = _twapPoints;
+
+    if (_maxTwapObservationInterval < VELO_OBSERVATION_PERIOD) {
+      revert TwapObservationIntervalTooShort();
+    }
+    maxTwapObservationInterval = _maxTwapObservationInterval;
+
+    if (_maxStablePriceDeviation < DECIMALS) {
+      revert StablePriceDeviationTooLow();
+    }
+    if (_maxStablePriceDeviation > MAX_STABLE_PRICE_DEVIATION) {
+      revert StablePriceDeviationTooHigh();
+    }
+    maxStablePriceDeviation = _maxStablePriceDeviation;
+
+    if (_maxPessimisticPriceAge == 0) {
+      revert PessimisticPriceAgeTooShort();
+    }
+    maxPessimisticPriceAge = _maxPessimisticPriceAge;
 
     // A heartbeat is the amount of time after which we consider a chainlink feed's price to be stale. For major
     // assets like BTC and ETH, this value is 3600 (1 hour). For less actively traded assets, this can be as high as
@@ -179,6 +252,20 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
   error GracePeriodNotOver();
   error NotOperator();
   error NoRecentPriceUpdates();
+  error TwapObservationIntervalTooShort();
+  error TwapObservationTooOld();
+  error TwapObservationIntervalTooLong();
+  error TwapObservationNotPostRecovery();
+  error StablePriceDeviationTooLow();
+  error StablePriceDeviationTooHigh();
+  error StablePriceDeviation();
+  error NoPostSequencerRecoveryPriceUpdate();
+  error PessimisticPriceAgeTooShort();
+  error PessimisticPriceStale();
+  error InvalidDerivedPrice();
+  error InvalidLpPrice();
+  error NoValidPriceUpdates();
+  error PessimisticPriceWindowNotReady();
 
   /* ========== VIEW FUNCTIONS ========== */
 
@@ -221,10 +308,12 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
       revert WrongVaultForPool();
     }
 
+    uint256 assetsPerShare = vault.previewRedeem(10 ** vault.decimals());
+
     if (_usePessimisticPricing) {
-      return (_getAdjustedPrice(_pool) * vault.convertToAssets(DECIMALS)) / DECIMALS;
+      return (_getAdjustedPrice(_pool) * assetsPerShare) / DECIMALS;
     } else {
-      return (_getFairReservesPricing(_pool) * vault.convertToAssets(DECIMALS)) / DECIMALS;
+      return (_getFairReservesPricing(_pool) * assetsPerShare) / DECIMALS;
     }
   }
 
@@ -242,10 +331,12 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
       revert WrongVaultForPool();
     }
 
+    uint256 assetsPerShare = ShareValueHelper.sharesToAmount(_vault, 10 ** vault.decimals());
+
     if (_usePessimisticPricing) {
-      return (_getAdjustedPrice(_pool) * ShareValueHelper.sharesToAmount(_vault, DECIMALS)) / DECIMALS;
+      return (_getAdjustedPrice(_pool) * assetsPerShare) / DECIMALS;
     } else {
-      return (_getFairReservesPricing(_pool) * ShareValueHelper.sharesToAmount(_vault, DECIMALS)) / DECIMALS;
+      return (_getFairReservesPricing(_pool) * assetsPerShare) / DECIMALS;
     }
   }
 
@@ -293,41 +384,37 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
       revert PriceInvalid();
     }
 
-    // make sure the sequencer is up
-    // uint80 roundID int256 sequencerAnswer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound
-    (, int256 sequencerAnswer, uint256 startedAt,,) = sequencerUptimeFeed.latestRoundData();
-
-    // Answer == 0: L2 Sequencer is up
-    // Answer == 1: L2 Sequencer is down
-    if (sequencerAnswer == 1) {
-      revert SequencerDown();
-    }
-
-    // Make sure a grace period of one hour has passed after the sequencer is back up.
-    uint256 timeSinceUp = block.timestamp - startedAt;
-    if (timeSinceUp < 3600) {
-      revert GracePeriodNotOver();
-    }
+    _checkSequencerUpAndGracePeriodOver();
 
     currentPrice = uint256(price);
   }
 
   /**
-   * @notice Returns the TWAP price for a token relative to the other token in its pool.
-   * @dev Note that we can customize the length of points but we default to 4 points (2 hours). Additionally, if a
-   *  pool is very small, it may not be priced as accurately if we attempt to use 1 full token to price.
-   * @param _token The address of the token to get the price of, and that we are swapping in.
-   * @param _tokenAmount Amount of the token we are swapping in.
-   * @return twapPrice Amount of other token we get when swapping in _tokenAmount looking back over our TWAP period.
+   * @notice Returns the no-slippage TWAP quote for a token relative to the other token in its pool.
+   * @dev Samples Velodrome's stored observations like pool.quote(), but computes a marginal price from the sampled
+   *  reserves instead of simulating a finite swap through the pool curve.
+   * @param _token The address of the token to price, and that we are notionally inputting.
+   * @param _tokenAmount Amount of the token we are pricing.
+   * @return twapPrice Amount of other token implied by _tokenAmount over our TWAP period.
    */
   function getTwapPrice(address _token, uint256 _tokenAmount) public view returns (uint256 twapPrice) {
     IVeloPool poolContract = IVeloPool(pool);
 
-    // swapping one of our token gets us this many otherToken, returned in decimals of the other token
-    twapPrice = poolContract.quote(_token, _tokenAmount, points);
+    (uint256 i, uint256 length) = _getTwapStartIndex(poolContract);
+
+    for (; i < length;) {
+      (uint256 reserve0Average, uint256 reserve1Average) = _getAverageReserves(poolContract, i);
+      twapPrice += _getMarginalAmountOut(_token, _tokenAmount, reserve0Average, reserve1Average);
+
+      unchecked {
+        i++;
+      }
+    }
+
+    twapPrice /= points;
   }
 
-  // by default we use 0.01 tokens in this function to more accurately price small pools
+  // derive missing token prices directly from TWAP reserve ratios to avoid precision loss from tiny raw quotes
   function getTokenPrices() public view returns (uint256 price0, uint256 price1) {
     // check if we have chainlink feeds or TWAP for each token
     if (token0Feed != address(0)) {
@@ -335,13 +422,19 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
       if (token1Feed != address(0)) {
         price1 = getChainlinkPrice(1); // returned with 8 decimals
       } else {
-        // get twap price for token1. this is the amount of token1 we would get from 0.01 token0
-        price1 = (price0 * decimals1) / (getTwapPrice(token0, decimals0 / 100) * 100);
+        // derive token1's price by averaging each sampled token1/token0 price
+        price1 = _getTwapDerivedTokenPrice(token0, price0);
+        if (price1 == 0) {
+          revert InvalidDerivedPrice();
+        }
       }
     } else if (token1Feed != address(0)) {
       price1 = getChainlinkPrice(1); // returned with 8 decimals
-      // get twap price for token0. this is the amount of token0 we would get from 0.01 token1
-      price0 = (price1 * decimals0) / (getTwapPrice(token1, decimals1 / 100) * 100);
+      // derive token0's price by averaging each sampled token0/token1 price
+      price0 = _getTwapDerivedTokenPrice(token1, price1);
+      if (price0 == 0) {
+        revert InvalidDerivedPrice();
+      }
     }
   }
 
@@ -362,16 +455,26 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
   function _updatePrice() internal {
     // get current fair reserves pricing
     uint256 currentPrice = _getFairReservesPricing(pool);
+    if (currentPrice == 0) {
+      revert InvalidLpPrice();
+    }
 
     // increment our counter whether we store the price or not
     uint256 day = currentDay();
+    bool isFirstUpdate = dailyUpdates[day] == 0;
     dailyUpdates[day] += 1;
+    lastPriceUpdateTime = block.timestamp;
 
     // store price if it's today's low
     uint256 todaysLow = dailyLow[day];
-    if (todaysLow == 0 || currentPrice < todaysLow) {
-      dailyLow[day] = currentPrice;
-      emit RecordDailyLow(currentPrice);
+    if (isFirstUpdate || currentPrice < todaysLow) {
+      // for volatile single-feed pools, fail soft: clamp the recorded low to this day's floor instead of
+      // reverting, so a legitimate sharp drop keeps the oracle live and steps the cached low down at the
+      // bounded per-day rate. no-op for stable / dual-feed pools.
+      uint256 lowToStore = _clampSingleFeedDailyLow(currentPrice, day);
+      dailyLow[day] = lowToStore;
+      lastValidLowDay = day;
+      emit RecordDailyLow(lowToStore);
     }
   }
 
@@ -381,31 +484,71 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
 
   // adjust our reported pool price as needed for 48-hour lows and hard upper/lower limits
   function _getAdjustedPrice(address _pool) internal view returns (uint256 adjustedPrice) {
+    uint256 sequencerStartedAt = _checkSequencerUpAndGracePeriodOver();
+    if (lastPriceUpdateTime <= sequencerStartedAt) {
+      revert NoPostSequencerRecoveryPriceUpdate();
+    }
+    if (block.timestamp - lastPriceUpdateTime > maxPessimisticPriceAge) {
+      revert PessimisticPriceStale();
+    }
+
+    // For dual-feed stable pools, refuse to serve a cached low while the trusted feeds currently show a depeg
+    // beyond the allowed band: the cached low was computed under in-band conditions the oracle would now reject.
+    // This makes the read path fail closed (the relayer turns the revert into invalidity) the moment a depeg
+    // appears, rather than vouching for a stale in-band price until maxPessimisticPriceAge elapses.
+    // Single-feed stable pools are intentionally not rechecked here: their unfed price is the lagging TWAP value,
+    // so the trusted-side cap (see _capSingleFeedPrice) is the relevant defense; volatile pools have no peg band.
+    if (stable && !_isSingleFeed()) {
+      (uint256 price0, uint256 price1) = getTokenPrices();
+      _validateStablePriceDeviation(price0, price1);
+    }
+
     // start off with our standard price
     uint256 day = currentDay();
 
     // if we haven't updated yet today, pretend it's yesterday instead
     if (dailyUpdates[day] == 0) {
+      if (day == 0) {
+        revert NoRecentPriceUpdates();
+      }
       day -= 1;
       if (dailyUpdates[day] == 0) {
         revert NoRecentPriceUpdates();
       }
     }
 
-    // get today's low
-    uint256 todaysLow = dailyLow[day];
+    _requirePopulatedPessimisticWindow(day);
 
-    // get yesterday's low
-    uint256 yesterdaysLow = dailyLow[day - 1];
+    adjustedPrice = _minNonZeroPrice(adjustedPrice, dailyLow[day]);
 
-    // calculate price based on two-day low
-    adjustedPrice = todaysLow > yesterdaysLow && yesterdaysLow > 0 ? yesterdaysLow : todaysLow;
+    if (day > 0 && dailyUpdates[day - 1] > 0) {
+      adjustedPrice = _minNonZeroPrice(adjustedPrice, dailyLow[day - 1]);
+    }
 
-    // if using three-day low, compare again
-    if (useThreeDayLow) {
-      uint256 dayBeforeYesterdaysLow = dailyLow[day - 2];
-      adjustedPrice =
-        adjustedPrice > dayBeforeYesterdaysLow && dayBeforeYesterdaysLow > 0 ? dayBeforeYesterdaysLow : adjustedPrice;
+    if (useThreeDayLow && day > 1 && dailyUpdates[day - 2] > 0) {
+      adjustedPrice = _minNonZeroPrice(adjustedPrice, dailyLow[day - 2]);
+    }
+
+    if (adjustedPrice == 0) {
+      revert NoValidPriceUpdates();
+    }
+  }
+
+  function _checkSequencerUpAndGracePeriodOver() internal view returns (uint256 startedAt) {
+    // uint80 roundID int256 sequencerAnswer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound
+    int256 sequencerAnswer;
+    (, sequencerAnswer, startedAt,,) = sequencerUptimeFeed.latestRoundData();
+
+    // Answer == 0: L2 Sequencer is up
+    // Answer == 1: L2 Sequencer is down
+    if (sequencerAnswer == 1) {
+      revert SequencerDown();
+    }
+
+    // Make sure a grace period of one hour has passed after the sequencer is back up.
+    uint256 timeSinceUp = block.timestamp - startedAt;
+    if (timeSinceUp < 3600) {
+      revert GracePeriodNotOver();
     }
   }
 
@@ -416,22 +559,297 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
     (uint256 reserve0, uint256 reserve1,) = poolContract.getReserves();
 
     // make sure our reserves are normalized to 18 decimals (looking at you, USDC)
-    reserve0 = (reserve0 * DECIMALS) / decimals0;
-    reserve1 = (reserve1 * DECIMALS) / decimals1;
+    reserve0 = _normalizeReserve(reserve0, decimals0);
+    reserve1 = _normalizeReserve(reserve1, decimals1);
 
     // pull our prices
     (uint256 price0, uint256 price1) = getTokenPrices();
 
+    uint256 totalSupply = poolContract.totalSupply();
+
     if (stable) {
-      fairReservesPricing =
-        _calculate_stable_lp_token_price(poolContract.totalSupply(), price0, price1, reserve0, reserve1, 8);
+      _validateStablePriceDeviation(price0, price1);
+      fairReservesPricing = _calculate_stable_lp_token_price(totalSupply, price0, price1, reserve0, reserve1, 8);
     } else {
-      uint256 k = FixedPointMathLib.sqrt(reserve0 * reserve1); // xy = k, p0r0' = p1r1', this is in 1e18
+      uint256 k = _getVolatileGeometricMean(reserve0, reserve1); // xy = k, p0r0' = p1r1', this is in 1e18
       uint256 p = FixedPointMathLib.sqrt(price0 * 1e16 * price1); // boost this to 1e16 to give us more precision
 
       // we want k and total supply to have same number of decimals so price has decimals of chainlink oracle
-      fairReservesPricing = (2 * p * k) / (1e8 * poolContract.totalSupply());
+      fairReservesPricing = FixedPointMathLib.mulDivDownFullPrecision(2 * p, k, totalSupply) / 1e8;
     }
+
+    // for single-feed pools (volatile or stable), bound the LP price by the value of the trusted (fed) side.
+    // no-op for dual-feed pools.
+    fairReservesPricing = _capSingleFeedPrice(fairReservesPricing, totalSupply, price0, price1);
+  }
+
+  function _capSingleFeedPrice(
+    uint256 _lpPrice,
+    uint256 _totalSupply,
+    uint256 _price0,
+    uint256 _price1
+  ) internal view returns (uint256 cappedPrice) {
+    cappedPrice = _lpPrice;
+    if (!_isSingleFeed()) return cappedPrice;
+
+    // Bound the LP price by twice the value of the trusted (fed) side, using TWAP-averaged reserves so the
+    // bound cannot be moved by a single-block reserve manipulation (a spot drain/inflation no longer collapses
+    // or inflates the cached low). For stable pools the bound roughly equals fair value at balance, so it will
+    // bind -- and conservatively underprice by ~the imbalance fraction -- during a sustained imbalance toward
+    // the unfed side. That pessimistic-direction cost is the accepted price of resisting unfed-token depeg
+    // overvaluation, where the trusted reserve drains while the TWAP-derived unfed price still lags near peg.
+    (uint256 reserve0Average, uint256 reserve1Average) = _getTwapAverageReserves();
+
+    uint256 cap;
+    if (token0Feed != address(0)) {
+      cap = 2 * FixedPointMathLib.mulDivDownFullPrecision(reserve0Average, _price0, _totalSupply);
+    } else {
+      cap = 2 * FixedPointMathLib.mulDivDownFullPrecision(reserve1Average, _price1, _totalSupply);
+    }
+
+    if (_lpPrice > cap) cappedPrice = cap;
+  }
+
+  // average of the per-interval TWAP reserves over the configured window, normalized to 18 decimals
+  function _getTwapAverageReserves() internal view returns (uint256 reserve0Average, uint256 reserve1Average) {
+    IVeloPool poolContract = IVeloPool(pool);
+    (uint256 i, uint256 length) = _getTwapStartIndex(poolContract);
+
+    uint256 reserve0Sum;
+    uint256 reserve1Sum;
+    for (; i < length;) {
+      (uint256 reserve0Interval, uint256 reserve1Interval) = _getAverageReserves(poolContract, i);
+      reserve0Sum += reserve0Interval;
+      reserve1Sum += reserve1Interval;
+
+      unchecked {
+        i++;
+      }
+    }
+
+    reserve0Average = _normalizeReserve(reserve0Sum / points, decimals0);
+    reserve1Average = _normalizeReserve(reserve1Sum / points, decimals1);
+  }
+
+  function _validateStablePriceDeviation(uint256 _price0, uint256 _price1) internal view {
+    (uint256 higherPrice, uint256 lowerPrice) = _price0 > _price1 ? (_price0, _price1) : (_price1, _price0);
+    uint256 priceDeviation = FixedPointMathLib.mulDivDownFullPrecision(higherPrice, DECIMALS, lowerPrice);
+
+    if (priceDeviation > maxStablePriceDeviation) {
+      revert StablePriceDeviation();
+    }
+  }
+
+  function _minNonZeroPrice(uint256 _currentPrice, uint256 _candidatePrice) internal pure returns (uint256 _price) {
+    if (_candidatePrice == 0) return _currentPrice;
+    if (_currentPrice == 0 || _candidatePrice < _currentPrice) return _candidatePrice;
+    return _currentPrice;
+  }
+
+  function _normalizeReserve(uint256 _reserve, uint256 _decimals) internal pure returns (uint256 _normalizedReserve) {
+    _normalizedReserve = FixedPointMathLib.mulDivDownFullPrecision(_reserve, DECIMALS, _decimals);
+  }
+
+  function _getVolatileGeometricMean(uint256 _reserve0, uint256 _reserve1) internal pure returns (uint256 _k) {
+    if (_reserve0 == 0 || _reserve1 == 0) return 0;
+
+    // Compute the exact geometric mean whenever the raw product fits in uint256. This is the common case and a
+    // far wider domain than the 1e27 magnitude guard used previously, which truncated a small reserve to zero
+    // (returning k == 0 for a validly priceable pool) any time the other reserve crossed 1e27.
+    if (_reserve0 <= type(uint256).max / _reserve1) {
+      return FixedPointMathLib.sqrt(_reserve0 * _reserve1);
+    }
+
+    // Genuine overflow territory (both reserves enormous, physically unrealizable for a real pool): scale down
+    // before the sqrt. Floor division can zero a dust reserve here; returning 0 is the conservative fallback.
+    uint256 maxReserve = _reserve0 > _reserve1 ? _reserve0 : _reserve1;
+    uint256 scale = _ceilDiv(maxReserve, VOLATILE_GEOMEAN_SCALE_LIMIT);
+
+    uint256 scaledReserve0 = _reserve0 / scale;
+    uint256 scaledReserve1 = _reserve1 / scale;
+    if (scaledReserve0 == 0 || scaledReserve1 == 0) return 0;
+
+    // Bound the rescale so sqrt(...) * scale cannot itself overflow; fall back to 0 if it would.
+    uint256 root = FixedPointMathLib.sqrt(scaledReserve0 * scaledReserve1);
+    if (root > type(uint256).max / scale) return 0;
+
+    _k = root * scale;
+  }
+
+  function _requirePopulatedPessimisticWindow(uint256 _day) internal view {
+    if (!useThreeDayLow) return;
+    if (_day < 2 || !_hasValidDailyLow(_day) || !_hasValidDailyLow(_day - 1) || !_hasValidDailyLow(_day - 2)) {
+      revert PessimisticPriceWindowNotReady();
+    }
+  }
+
+  function _hasValidDailyLow(uint256 _day) internal view returns (bool _valid) {
+    _valid = dailyUpdates[_day] > 0 && dailyLow[_day] > 0;
+  }
+
+  /// @notice Fail-soft daily-low floor for volatile single-feed pools.
+  /// @dev Returns the value that should actually be stored as the day's low: the live price, or the day's floor
+  ///  if the live price is below it. The floor is frozen on the first recorded low of each day and anchored to
+  ///  the carry-in low from a prior day (never the evolving intra-day low), so the bound is a fixed per-day
+  ///  reference rather than a value that ratchets down with each same-day update (L-12). After a keeper gap the
+  ///  floor decays 20% per elapsed day, capped, so a missed day still enforces a bound instead of no-oping
+  ///  (L-16). Because we clamp rather than revert, a legitimate sharp drop is recorded at the floor and the
+  ///  oracle stays live, stepping the cached low down on subsequent days instead of freezing (L-20/L-22).
+  function _clampSingleFeedDailyLow(uint256 _currentPrice, uint256 _day) internal returns (uint256 _lowToStore) {
+    _lowToStore = _currentPrice;
+    if (stable || !_isSingleFeed()) return _lowToStore;
+
+    // freeze this day's floor on its first recorded low
+    if (clampFloorDay != _day) {
+      clampFloorDay = _day;
+
+      uint256 elapsedDays;
+      uint256 anchorLow;
+      if (lastValidLowDay == 0) {
+        // no prior day to anchor against: anchor to this first reading of the day. The floor is frozen here, so
+        // later same-day updates are still bounded without ratcheting, while the first reading is unconstrained.
+        anchorLow = _currentPrice;
+        elapsedDays = 1;
+      } else {
+        // anchor to the carry-in low from the last day that recorded one, decayed per elapsed day
+        anchorLow = dailyLow[lastValidLowDay];
+        elapsedDays = _day - lastValidLowDay;
+      }
+
+      if (elapsedDays > MAX_SINGLE_FEED_LOW_DECAY_DAYS) {
+        elapsedDays = MAX_SINGLE_FEED_LOW_DECAY_DAYS;
+      }
+
+      uint256 floor = anchorLow;
+      for (uint256 i = 0; i < elapsedDays;) {
+        floor = FixedPointMathLib.mulDivDownFullPrecision(floor, BPS - MAX_SINGLE_FEED_DAILY_LOW_DECREASE_BPS, BPS);
+        unchecked {
+          i++;
+        }
+      }
+      clampFloor = floor;
+    }
+
+    if (clampFloor != 0 && _currentPrice < clampFloor) {
+      _lowToStore = clampFloor;
+    }
+  }
+
+  function _isSingleFeed() internal view returns (bool _singleFeed) {
+    _singleFeed = (token0Feed == address(0)) != (token1Feed == address(0));
+  }
+
+  function _getMarginalAmountOut(
+    address _token,
+    uint256 _amountIn,
+    uint256 _reserve0,
+    uint256 _reserve1
+  ) internal view returns (uint256 amountOut) {
+    bool tokenInIsToken0 = _token == token0;
+
+    if (stable) {
+      uint256 normalizedReserve0 = _normalizeReserve(_reserve0, decimals0);
+      uint256 normalizedReserve1 = _normalizeReserve(_reserve1, decimals1);
+      (uint256 reserveA, uint256 reserveB) =
+        tokenInIsToken0 ? (normalizedReserve0, normalizedReserve1) : (normalizedReserve1, normalizedReserve0);
+      uint256 normalizedAmountIn = _normalizeReserve(_amountIn, tokenInIsToken0 ? decimals0 : decimals1);
+      (uint256 derivativeA, uint256 derivativeB) = _getScaledStableDerivativePair(reserveA, reserveB);
+      uint256 normalizedAmountOut = FixedPointMathLib.mulDivDown(normalizedAmountIn, derivativeB, derivativeA);
+
+      amountOut = FixedPointMathLib.mulDivDownFullPrecision(
+        normalizedAmountOut, tokenInIsToken0 ? decimals1 : decimals0, DECIMALS
+      );
+    } else {
+      (uint256 reserveA, uint256 reserveB) = tokenInIsToken0 ? (_reserve0, _reserve1) : (_reserve1, _reserve0);
+      amountOut = FixedPointMathLib.mulDivDown(_amountIn, reserveB, reserveA);
+    }
+  }
+
+  function _getTwapDerivedTokenPrice(
+    address _knownToken,
+    uint256 _knownTokenPrice
+  ) internal view returns (uint256 twapPrice) {
+    IVeloPool poolContract = IVeloPool(pool);
+    bool knownTokenIsToken0 = _knownToken == token0;
+
+    (uint256 i, uint256 length) = _getTwapStartIndex(poolContract);
+
+    for (; i < length;) {
+      (uint256 reserve0Average, uint256 reserve1Average) = _getAverageReserves(poolContract, i);
+      (uint256 knownReserve, uint256 derivedReserve) =
+        _getNormalizedReservePair(knownTokenIsToken0, reserve0Average, reserve1Average);
+      if (knownReserve == 0 || derivedReserve == 0) {
+        revert InvalidDerivedPrice();
+      }
+
+      // Accumulate each sample at 1e18-boosted precision and floor only once (below), instead of flooring every
+      // sample to 8 decimals before summing. Round-then-average could floor sub-unit-but-nonzero sample prices
+      // to zero and drag a valid average down to zero, reverting the update (L-19). The 1e18 boost is safe: a
+      // mulDivDownFullPrecision uses 512-bit intermediates and an 8-decimal Chainlink price leaves ample headroom.
+      if (stable) {
+        (uint256 knownDerivative, uint256 derivedDerivative) =
+          _getScaledStableDerivativePair(knownReserve, derivedReserve);
+        if (knownDerivative == 0 || derivedDerivative == 0) {
+          revert InvalidDerivedPrice();
+        }
+        twapPrice +=
+          FixedPointMathLib.mulDivDownFullPrecision(_knownTokenPrice * 1e18, knownDerivative, derivedDerivative);
+      } else {
+        twapPrice += FixedPointMathLib.mulDivDownFullPrecision(_knownTokenPrice * 1e18, knownReserve, derivedReserve);
+      }
+
+      unchecked {
+        i++;
+      }
+    }
+
+    twapPrice /= (points * 1e18);
+  }
+
+  function _getNormalizedReservePair(
+    bool _knownTokenIsToken0,
+    uint256 _reserve0,
+    uint256 _reserve1
+  ) internal view returns (uint256 knownReserve, uint256 derivedReserve) {
+    uint256 normalizedReserve0 = _normalizeReserve(_reserve0, decimals0);
+    uint256 normalizedReserve1 = _normalizeReserve(_reserve1, decimals1);
+    (knownReserve, derivedReserve) =
+      _knownTokenIsToken0 ? (normalizedReserve0, normalizedReserve1) : (normalizedReserve1, normalizedReserve0);
+  }
+
+  function _getTwapStartIndex(IVeloPool _poolContract) internal view returns (uint256 startIndex, uint256 length) {
+    length = _poolContract.observationLength() - 1;
+    startIndex = length - points;
+
+    IVeloPool.Observation memory latestObservation = _poolContract.observations(length);
+    if (block.timestamp - latestObservation.timestamp > maxTwapObservationInterval) {
+      revert TwapObservationTooOld();
+    }
+
+    // Reject any window whose earliest sampled observation predates the latest sequencer recovery. During an
+    // outage no observations are written, so the first interval after a restart would span the gap and average
+    // frozen pre-outage reserves into the derived price. Observation timestamps are monotonic, so a start
+    // observation at/after recovery guarantees no sampled interval straddles recovery (per-interval validation
+    // is redundant). Fail closed until enough post-recovery observations exist (~points * 30 min after restart).
+    uint256 sequencerStartedAt = _checkSequencerUpAndGracePeriodOver();
+    if (_poolContract.observations(startIndex).timestamp < sequencerStartedAt) {
+      revert TwapObservationNotPostRecovery();
+    }
+  }
+
+  function _getAverageReserves(
+    IVeloPool _poolContract,
+    uint256 _index
+  ) internal view returns (uint256 reserve0Average, uint256 reserve1Average) {
+    IVeloPool.Observation memory nextObservation = _poolContract.observations(_index + 1);
+    IVeloPool.Observation memory currentObservation = _poolContract.observations(_index);
+    uint256 timeElapsed = nextObservation.timestamp - currentObservation.timestamp;
+    if (timeElapsed > maxTwapObservationInterval) {
+      revert TwapObservationIntervalTooLong();
+    }
+
+    reserve0Average = (nextObservation.reserve0Cumulative - currentObservation.reserve0Cumulative) / timeElapsed;
+    reserve1Average = (nextObservation.reserve1Cumulative - currentObservation.reserve1Cumulative) / timeElapsed;
   }
 
   // solves for cases where curve is x^3 * y + y^3 * x = k
@@ -444,23 +862,105 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
     uint256 reserve1,
     uint256 priceDecimals
   ) internal pure returns (uint256) {
-    uint256 k = _getK(reserve0, reserve1);
     // fair_reserves = ( (k * (price0 ** 3) * (price1 ** 3)) )^(1/4) / ((price0 ** 2) + (price1 ** 2));
     price0 *= 1e18 / (10 ** priceDecimals); // convert to 18 dec
     price1 *= 1e18 / (10 ** priceDecimals);
-    uint256 a = FixedPointMathLib.rpow(price0, 3, 1e18); // keep same decimals as chainlink
-    uint256 b = FixedPointMathLib.rpow(price1, 3, 1e18);
-    uint256 c = FixedPointMathLib.rpow(price0, 2, 1e18);
-    uint256 d = FixedPointMathLib.rpow(price1, 2, 1e18);
+    uint256 stablePriceScale = _getStablePriceScale(price0, price1);
+    price0 *= stablePriceScale;
+    price1 *= stablePriceScale;
 
-    uint256 p0 = k * FixedPointMathLib.mulWadDown(a, b); // 2*18 decimals
+    uint256 stablePricingScale = _getStablePricingScale(reserve0, reserve1, price0, price1);
+    reserve0 /= stablePricingScale;
+    reserve1 /= stablePricingScale;
 
-    uint256 fair = p0 / (c + d); // number of decimals is 18
+    uint256 frth_fair;
+    {
+      uint256 k = _getK(reserve0, reserve1);
+      uint256 a = FixedPointMathLib.rpow(price0, 3, 1e18); // keep same decimals as chainlink
+      uint256 b = FixedPointMathLib.rpow(price1, 3, 1e18);
+      uint256 c = FixedPointMathLib.rpow(price0, 2, 1e18);
+      uint256 d = FixedPointMathLib.rpow(price1, 2, 1e18);
 
-    // each sqrt divides the num decimals by 2. So need to replenish the decimals midway through with another 1e18
-    uint256 frth_fair = FixedPointMathLib.sqrt(FixedPointMathLib.sqrt(fair * 1e18) * 1e18); // number of decimals is 18
+      uint256 fair = _getStableFair(k, a, b, c + d);
 
-    return 2 * ((frth_fair * (10 ** priceDecimals)) / total_supply); // converts to chainlink decimals
+      // each sqrt divides the num decimals by 2. So need to replenish the decimals midway through with another 1e18
+      frth_fair = FixedPointMathLib.sqrt(FixedPointMathLib.sqrt(fair * 1e18) * 1e18); // number of decimals is 18
+    }
+
+    return _scaleStableLpTokenPrice(total_supply, frth_fair, stablePricingScale, stablePriceScale, priceDecimals);
+  }
+
+  function _scaleStableLpTokenPrice(
+    uint256 _totalSupply,
+    uint256 _frthFair,
+    uint256 _stablePricingScale,
+    uint256 _stablePriceScale,
+    uint256 _priceDecimals
+  ) internal pure returns (uint256 _price) {
+    uint256 fairReserve =
+      FixedPointMathLib.mulDivDownFullPrecision(2 * _frthFair, _stablePricingScale, _stablePriceScale);
+
+    _price = FixedPointMathLib.mulDivDownFullPrecision(fairReserve, 10 ** _priceDecimals, _totalSupply);
+  }
+
+  function _getStableFair(
+    uint256 _k,
+    uint256 _a,
+    uint256 _b,
+    uint256 _denominator
+  ) internal pure returns (uint256 _fair) {
+    uint256 kTimesA = FixedPointMathLib.mulDivDownFullPrecision(_k, _a, _denominator);
+    _fair = FixedPointMathLib.mulDivDownFullPrecision(kTimesA, _b, DECIMALS);
+  }
+
+  function _getStablePriceScale(uint256 _price0, uint256 _price1) internal pure returns (uint256 _stablePriceScale) {
+    uint256 maxPrice = _price0 > _price1 ? _price0 : _price1;
+    if (maxPrice >= DECIMALS) return 1;
+
+    _stablePriceScale = _ceilDiv(DECIMALS, maxPrice);
+  }
+
+  function _getStablePricingScale(
+    uint256 _reserve0,
+    uint256 _reserve1,
+    uint256 _price0,
+    uint256 _price1
+  ) internal pure returns (uint256 stablePricingScale) {
+    uint256 maxReserve = _reserve0 > _reserve1 ? _reserve0 : _reserve1;
+    uint256 maxPrice = _price0 > _price1 ? _price0 : _price1;
+    uint256 maxReserveValue = FixedPointMathLib.mulDivDownFullPrecision(maxReserve, maxPrice, DECIMALS);
+
+    stablePricingScale = _ceilDiv(maxReserve, STABLE_LP_PRICING_SCALE_LIMIT);
+    uint256 valueScale = _ceilDiv(maxReserveValue, STABLE_LP_PRICING_SCALE_LIMIT);
+    if (valueScale > stablePricingScale) stablePricingScale = valueScale;
+    if (stablePricingScale == 0) stablePricingScale = 1;
+  }
+
+  function _ceilDiv(uint256 _x, uint256 _y) internal pure returns (uint256 _z) {
+    if (_x == 0) return 0;
+    return ((_x - 1) / _y) + 1;
+  }
+
+  function _getScaledStableDerivativePair(
+    uint256 _reserveA,
+    uint256 _reserveB
+  ) internal pure returns (uint256 derivativeA, uint256 derivativeB) {
+    (uint256 scaledReserveA, uint256 scaledReserveB) = _scaleStableDerivativeReserves(_reserveA, _reserveB);
+
+    derivativeA = _stableDerivative(scaledReserveA, scaledReserveB);
+    derivativeB = _stableDerivative(scaledReserveB, scaledReserveA);
+  }
+
+  function _scaleStableDerivativeReserves(
+    uint256 _reserveA,
+    uint256 _reserveB
+  ) internal pure returns (uint256 scaledReserveA, uint256 scaledReserveB) {
+    uint256 maxReserve = _reserveA > _reserveB ? _reserveA : _reserveB;
+    uint256 scale = _ceilDiv(maxReserve, STABLE_DERIVATIVE_SCALE_LIMIT);
+    if (scale <= 1) return (_reserveA, _reserveB);
+
+    scaledReserveA = _ceilDiv(_reserveA, scale);
+    scaledReserveB = _ceilDiv(_reserveB, scale);
   }
 
   function _getK(uint256 x, uint256 y) internal pure returns (uint256) {
@@ -471,6 +971,11 @@ contract PessimisticVeloSingleOracle is Ownable2Step {
     uint256 newY = FixedPointMathLib.mulWadDown(y_cubed, x);
 
     return newX + newY; // 18 decimals
+  }
+
+  function _stableDerivative(uint256 x0, uint256 y) internal pure returns (uint256 derivative) {
+    derivative = 3 * FixedPointMathLib.mulWadDown(x0, FixedPointMathLib.mulWadDown(y, y))
+      + FixedPointMathLib.mulWadDown(FixedPointMathLib.mulWadDown(x0, x0), x0);
   }
 
   /* ========== SETTERS ========== */

--- a/src/contracts/oracles/YearnVeloVaultRelayer.sol
+++ b/src/contracts/oracles/YearnVeloVaultRelayer.sol
@@ -43,6 +43,7 @@ contract YearnVeloVaultRelayer is AbstractVeloVaultRelayer, IYearnVeloVaultRelay
     }
 
     yearnVault = _yearnVault;
+    _initializePricePerFullShare();
   }
 
   function _getPricePerFullShare() internal view override returns (uint256 _pricePerFullShare) {

--- a/src/interfaces/external/IVeloPool.sol
+++ b/src/interfaces/external/IVeloPool.sol
@@ -4,6 +4,12 @@ pragma solidity 0.8.20;
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 
 interface IVeloPool is IERC20 {
+  struct Observation {
+    uint256 timestamp;
+    uint256 reserve0Cumulative;
+    uint256 reserve1Cumulative;
+  }
+
   /**
    * @notice Returns the value of tokens in existence.
    */
@@ -20,6 +26,10 @@ interface IVeloPool is IERC20 {
   function symbol() external view returns (string memory _symbol);
 
   function quote(address tokenIn, uint256 amountIn, uint256 granularity) external view returns (uint256);
+
+  function observationLength() external view returns (uint256);
+
+  function observations(uint256 index) external view returns (Observation memory);
 
   function getReserves() external view returns (uint256 _reserve0, uint256 _reserve1, uint256 _blockTimestampLast);
 

--- a/src/interfaces/oracles/IAbstractVeloVaultRelayer.sol
+++ b/src/interfaces/oracles/IAbstractVeloVaultRelayer.sol
@@ -8,6 +8,12 @@ import {IVeloPool} from '@interfaces/external/IVeloPool.sol';
 import {IPessimisticVeloLpOracle} from '@interfaces/external/IPessimisticVeloLpOracle.sol';
 
 interface IAbstractVeloVaultRelayer is IBaseOracle {
+  /**
+   * @notice Emitted when the accepted vault price per full share is updated
+   * @param _pricePerFullShare The new accepted price per full share [wad]
+   */
+  event UpdatePricePerFullShare(uint256 _pricePerFullShare);
+
   // --- Errors ---
 
   /// @notice Throws if the provided velo pool address is null
@@ -18,6 +24,9 @@ interface IAbstractVeloVaultRelayer is IBaseOracle {
 
   /// @notice Throws if the price is 0
   error AbstractVeloVaultRelayer_ZeroPrice();
+
+  /// @notice Throws if the vault price per full share is 0
+  error AbstractVeloVaultRelayer_InvalidPricePerFullShare();
 
   /**
    * @notice Address of the velo pool underlying the beefy vault
@@ -30,4 +39,17 @@ interface IAbstractVeloVaultRelayer is IBaseOracle {
    * @dev    Assumes that the price source is a valid IPessimisticVeloLpOracle
    */
   function veloLpOracle() external view returns (IPessimisticVeloLpOracle _veloPool);
+
+  /// @notice Accepted vault price per full share used for collateral pricing [wad]
+  function acceptedPricePerFullShare() external view returns (uint256 _acceptedPricePerFullShare);
+
+  /// @notice Timestamp of the latest accepted price per full share update
+  function lastPricePerFullShareUpdateTime() external view returns (uint256 _lastPricePerFullShareUpdateTime);
+
+  /// @notice Updates the accepted vault price per full share, capping upward movement
+  function updatePricePerFullShare() external returns (bool _updated);
+
+  /// @notice Returns the live (uncached) vault price per full share [wad]
+  /// @dev    External so the view pricing path can wrap it in try/catch; reverts if the underlying vault reverts
+  function livePricePerFullShare() external view returns (uint256 _pricePerFullShare);
 }

--- a/src/libraries/FixedPointMathLib.sol
+++ b/src/libraries/FixedPointMathLib.sol
@@ -56,6 +56,47 @@ library FixedPointMathLib {
     }
   }
 
+  /// @notice Calculates floor(x * y / denominator) with full precision.
+  /// @dev Adapted from Uniswap V3 FullMath.mulDiv.
+  function mulDivDownFullPrecision(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 z) {
+    /// @solidity memory-safe-assembly
+    assembly {
+      let mm := mulmod(x, y, not(0))
+      let prod0 := mul(x, y)
+      let prod1 := sub(sub(mm, prod0), lt(mm, prod0))
+
+      switch prod1
+      case 0 {
+        if iszero(denominator) { revert(0, 0) }
+        z := div(prod0, denominator)
+      }
+      default {
+        if iszero(gt(denominator, prod1)) { revert(0, 0) }
+
+        let remainder := mulmod(x, y, denominator)
+        prod1 := sub(prod1, gt(remainder, prod0))
+        prod0 := sub(prod0, remainder)
+
+        let twos := and(denominator, sub(0, denominator))
+        denominator := div(denominator, twos)
+        prod0 := div(prod0, twos)
+
+        twos := add(div(sub(0, twos), twos), 1)
+        prod0 := or(prod0, mul(prod1, twos))
+
+        let inverse := xor(mul(3, denominator), 2)
+        inverse := mul(inverse, sub(2, mul(denominator, inverse)))
+        inverse := mul(inverse, sub(2, mul(denominator, inverse)))
+        inverse := mul(inverse, sub(2, mul(denominator, inverse)))
+        inverse := mul(inverse, sub(2, mul(denominator, inverse)))
+        inverse := mul(inverse, sub(2, mul(denominator, inverse)))
+        inverse := mul(inverse, sub(2, mul(denominator, inverse)))
+
+        z := mul(prod0, inverse)
+      }
+    }
+  }
+
   function rpow(uint256 x, uint256 n, uint256 scalar) internal pure returns (uint256 z) {
     /// @solidity memory-safe-assembly
     assembly {

--- a/test/unit/jobs/OracleJob.t.sol
+++ b/test/unit/jobs/OracleJob.t.sol
@@ -3,7 +3,9 @@ pragma solidity 0.8.20;
 
 import {OracleJobForTest, IOracleJob} from '@test/mocks/OracleJobForTest.sol';
 import {IOracleRelayer} from '@interfaces/IOracleRelayer.sol';
+import {DelayedOracle} from '@contracts/oracles/DelayedOracle.sol';
 import {IDelayedOracle} from '@interfaces/oracles/IDelayedOracle.sol';
+import {IBaseOracle} from '@interfaces/oracles/IBaseOracle.sol';
 import {IPIDRateSetter} from '@interfaces/IPIDRateSetter.sol';
 import {IStabilityFeeTreasury} from '@interfaces/IStabilityFeeTreasury.sol';
 import {IJob} from '@interfaces/jobs/IJob.sol';
@@ -12,6 +14,31 @@ import {IModifiable} from '@interfaces/utils/IModifiable.sol';
 import {HaiTest, stdStorage, StdStorage} from '@test/utils/HaiTest.t.sol';
 
 import {Assertions} from '@libraries/Assertions.sol';
+
+contract PriceSourceForTest is IBaseOracle {
+  uint256 internal _value;
+  bool internal _valid;
+  string public symbol = 'PriceSource / USD';
+
+  constructor(uint256 __value, bool __valid) {
+    _value = __value;
+    _valid = __valid;
+  }
+
+  function setResult(uint256 __value, bool __valid) external {
+    _value = __value;
+    _valid = __valid;
+  }
+
+  function getResultWithValidity() external view returns (uint256 _result, bool _validity) {
+    return (_value, _valid);
+  }
+
+  function read() external view returns (uint256 _result) {
+    require(_valid, 'invalid');
+    return _value;
+  }
+}
 
 abstract contract Base is HaiTest {
   using stdStorage for StdStorage;
@@ -57,6 +84,12 @@ abstract contract Base is HaiTest {
 
   function _mockUpdateResult(bool _success) internal {
     vm.mockCall(address(mockDelayedOracle), abi.encodeCall(mockDelayedOracle.updateResult, ()), abi.encode(_success));
+  }
+
+  function _mockLastUpdateTime(uint256 _lastUpdateTime) internal {
+    vm.mockCall(
+      address(mockDelayedOracle), abi.encodeCall(mockDelayedOracle.lastUpdateTime, ()), abi.encode(_lastUpdateTime)
+    );
   }
 
   function _mockRewardAmount(uint256 _rewardAmount) internal {
@@ -160,6 +193,8 @@ contract Unit_OracleJob_WorkUpdateCollateralPrice is Base {
     _mockShouldWorkUpdateCollateralPrice(_shouldWorkUpdateCollateralPrice);
     _mockOracleRelayerCollateralParams(_cType, address(mockDelayedOracle), 0, 0);
     _mockUpdateResult(_updateResult);
+    // constant lastUpdateTime so before == after: an invalid updateResult reads as a no-op unless overridden
+    _mockLastUpdateTime(0);
   }
 
   function test_Revert_NotWorkable(bytes32 _cType) public {
@@ -171,10 +206,28 @@ contract Unit_OracleJob_WorkUpdateCollateralPrice is Base {
   }
 
   function test_Revert_InvalidPrice(bytes32 _cType) public {
+    // no-op case: updateResult() returns false AND lastUpdateTime does not advance -> revert (no reward farming)
     _mockValues(_cType, true, false);
 
     vm.expectRevert(IOracleJob.OracleJob_InvalidPrice.selector);
 
+    oracleJob.workUpdateCollateralPrice(_cType);
+  }
+
+  function test_Call_OracleRelayer_UpdateCollateralPrice_OnInvalidationTransition(bytes32 _cType) public {
+    // L-15: an invalid result that DOES advance lastUpdateTime is a genuine invalidation transition. The job
+    // must not revert; it must still push the (now invalid) result to the relayer so it reaches the SAFE engine.
+    vm.startPrank(user);
+    _mockShouldWorkUpdateCollateralPrice(true);
+    _mockOracleRelayerCollateralParams(_cType, address(mockDelayedOracle), 0, 0);
+    _mockUpdateResult(false);
+
+    bytes[] memory _lastUpdateTimes = new bytes[](2);
+    _lastUpdateTimes[0] = abi.encode(uint256(1));
+    _lastUpdateTimes[1] = abi.encode(uint256(2));
+    vm.mockCalls(address(mockDelayedOracle), abi.encodeCall(mockDelayedOracle.lastUpdateTime, ()), _lastUpdateTimes);
+
+    vm.expectCall(address(mockOracleRelayer), abi.encodeCall(mockOracleRelayer.updateCollateralPrice, (_cType)), 1);
     oracleJob.workUpdateCollateralPrice(_cType);
   }
 
@@ -189,6 +242,42 @@ contract Unit_OracleJob_WorkUpdateCollateralPrice is Base {
     emit Rewarded(user, REWARD_AMOUNT);
 
     oracleJob.workUpdateCollateralPrice(_cType);
+  }
+
+  function test_PropagatesInvalidationThroughRealDelayedOracleOverTwoCycles() public {
+    // L-15 end-to-end against a REAL DelayedOracle (not mocked updateResult/lastUpdateTime): a fail-closed price
+    // source must propagate to invalidity over the two-step delay via the rewarded keeper path, and neither
+    // rewarded call may revert. Pre-fix the first call reverts on updateResult()==false and invalidation never
+    // propagates.
+    vm.startPrank(user);
+    uint256 _updateDelay = 1 hours;
+    PriceSourceForTest _priceSource = new PriceSourceForTest(1e18, true);
+    DelayedOracle _delayedOracle = new DelayedOracle(IBaseOracle(address(_priceSource)), _updateDelay);
+
+    bytes32 _cType = bytes32('TEST');
+    _mockShouldWorkUpdateCollateralPrice(true);
+    _mockOracleRelayerCollateralParams(_cType, address(_delayedOracle), 0, 0);
+    // updateCollateralPrice lives on the etched mockOracleRelayer (returns void, never reverts)
+
+    (, bool _validStart) = _delayedOracle.getResultWithValidity();
+    assertTrue(_validStart);
+
+    // the price source goes fail-closed
+    _priceSource.setResult(0, false);
+
+    // cycle 1: invalidation staged into nextFeed; the rewarded call must reach updateCollateralPrice (no revert)
+    vm.warp(block.timestamp + _updateDelay);
+    vm.expectCall(address(mockOracleRelayer), abi.encodeCall(mockOracleRelayer.updateCollateralPrice, (_cType)));
+    oracleJob.workUpdateCollateralPrice(_cType);
+    (, bool _validAfterOne) = _delayedOracle.getResultWithValidity();
+    assertTrue(_validAfterOne); // currentFeed still the last valid value after one cycle
+
+    // cycle 2: invalidation reaches currentFeed and is now visible to the SAFE-engine-facing getter
+    vm.warp(block.timestamp + _updateDelay);
+    oracleJob.workUpdateCollateralPrice(_cType);
+    (uint256 _resultAfterTwo, bool _validAfterTwo) = _delayedOracle.getResultWithValidity();
+    assertFalse(_validAfterTwo);
+    assertEq(_resultAfterTwo, 0);
   }
 }
 

--- a/test/unit/oracles/AbstractVeloVaultRelayer.t.sol
+++ b/test/unit/oracles/AbstractVeloVaultRelayer.t.sol
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.20;
+
+import {AbstractVeloVaultRelayer} from '@contracts/oracles/AbstractVeloVaultRelayer.sol';
+import {DelayedOracle} from '@contracts/oracles/DelayedOracle.sol';
+import {IPessimisticVeloLpOracle} from '@interfaces/external/IPessimisticVeloLpOracle.sol';
+import {IVeloPool} from '@interfaces/external/IVeloPool.sol';
+import {IAbstractVeloVaultRelayer} from '@interfaces/oracles/IAbstractVeloVaultRelayer.sol';
+import {IBaseOracle} from '@interfaces/oracles/IBaseOracle.sol';
+import {HaiTest} from '@test/utils/HaiTest.t.sol';
+
+contract PessimisticVeloLpOracleForTest is IPessimisticVeloLpOracle {
+  error PriceUnavailable();
+
+  uint256 internal _price;
+  bool internal _revertOnRead;
+
+  constructor(uint256 __price) {
+    _price = __price;
+  }
+
+  function setPrice(uint256 __price) external {
+    _price = __price;
+  }
+
+  function setRevertOnRead(bool __revertOnRead) external {
+    _revertOnRead = __revertOnRead;
+  }
+
+  function getCurrentPoolPrice(bool) external view returns (uint256 _currentPoolPrice) {
+    if (_revertOnRead) {
+      revert PriceUnavailable();
+    }
+
+    return _price;
+  }
+}
+
+contract VeloVaultRelayerForTest is AbstractVeloVaultRelayer {
+  error PricePerFullShareUnavailable();
+
+  uint256 internal _pricePerFullShare;
+  bool internal _revertOnPricePerFullShare;
+
+  constructor(
+    IVeloPool _veloPool,
+    IPessimisticVeloLpOracle _veloLpOracle,
+    uint256 __pricePerFullShare
+  ) AbstractVeloVaultRelayer(_veloPool, _veloLpOracle, 'VeloVaultRelayerForTest') {
+    _pricePerFullShare = __pricePerFullShare;
+    _initializePricePerFullShare();
+  }
+
+  function setPricePerFullShare(uint256 __pricePerFullShare) external {
+    _pricePerFullShare = __pricePerFullShare;
+  }
+
+  function setRevertOnPricePerFullShare(bool __revertOnPricePerFullShare) external {
+    _revertOnPricePerFullShare = __revertOnPricePerFullShare;
+  }
+
+  function _getPricePerFullShare() internal view override returns (uint256 __pricePerFullShare) {
+    if (_revertOnPricePerFullShare) {
+      revert PricePerFullShareUnavailable();
+    }
+    return _pricePerFullShare;
+  }
+}
+
+contract Unit_AbstractVeloVaultRelayer is HaiTest {
+  IVeloPool internal veloPool = IVeloPool(mockContract('VeloPool'));
+  PessimisticVeloLpOracleForTest internal veloLpOracle;
+  VeloVaultRelayerForTest internal relayer;
+
+  function setUp() public {
+    veloLpOracle = new PessimisticVeloLpOracleForTest(2e8);
+    relayer = new VeloVaultRelayerForTest(veloPool, veloLpOracle, 1e18);
+  }
+
+  function test_Constructor_InitializesAcceptedPricePerFullShare() public view {
+    assertEq(relayer.acceptedPricePerFullShare(), 1e18);
+    assertEq(relayer.lastPricePerFullShareUpdateTime(), block.timestamp);
+
+    (uint256 result, bool valid) = relayer.getResultWithValidity();
+
+    assertTrue(valid);
+    assertEq(result, 2e18);
+  }
+
+  function test_GetResultWithValidity_ReturnsInvalidWhenLpOracleReverts() public {
+    veloLpOracle.setRevertOnRead(true);
+
+    (uint256 result, bool valid) = relayer.getResultWithValidity();
+
+    assertEq(result, 0);
+    assertFalse(valid);
+  }
+
+  function test_Read_RevertsWhenLpOracleReverts() public {
+    veloLpOracle.setRevertOnRead(true);
+
+    vm.expectRevert(PessimisticVeloLpOracleForTest.PriceUnavailable.selector);
+    relayer.read();
+  }
+
+  function test_GetResultWithValidity_ReturnsInvalidWhenLpOraclePriceIsZero() public {
+    veloLpOracle.setPrice(0);
+
+    (uint256 result, bool valid) = relayer.getResultWithValidity();
+
+    assertEq(result, 0);
+    assertFalse(valid);
+  }
+
+  function test_UpdatePricePerFullShare_AcceptsDecreaseImmediately() public {
+    relayer.setPricePerFullShare(0.5e18);
+
+    bool updated = relayer.updatePricePerFullShare();
+
+    assertTrue(updated);
+    assertEq(relayer.acceptedPricePerFullShare(), 0.5e18);
+    assertEq(relayer.lastPricePerFullShareUpdateTime(), block.timestamp);
+
+    (uint256 result,) = relayer.getResultWithValidity();
+    assertEq(result, 1e18);
+  }
+
+  function test_UpdatePricePerFullShare_AcceptsZeroAsInvalidatingDecrease() public {
+    relayer.setPricePerFullShare(0);
+
+    bool updated = relayer.updatePricePerFullShare();
+
+    assertTrue(updated);
+    assertEq(relayer.acceptedPricePerFullShare(), 0);
+    assertEq(relayer.lastPricePerFullShareUpdateTime(), block.timestamp);
+
+    (uint256 result, bool valid) = relayer.getResultWithValidity();
+
+    assertEq(result, 0);
+    assertFalse(valid);
+
+    vm.expectRevert(IAbstractVeloVaultRelayer.AbstractVeloVaultRelayer_ZeroPrice.selector);
+    relayer.read();
+  }
+
+  function test_UpdatePricePerFullShare_RecoversFromAcceptedZeroPricePerFullShare() public {
+    relayer.setPricePerFullShare(0);
+    relayer.updatePricePerFullShare();
+
+    relayer.setPricePerFullShare(1e18);
+
+    bool updated = relayer.updatePricePerFullShare();
+
+    assertTrue(updated);
+    assertEq(relayer.acceptedPricePerFullShare(), 1e18);
+
+    (uint256 result, bool valid) = relayer.getResultWithValidity();
+
+    assertEq(result, 2e18);
+    assertTrue(valid);
+  }
+
+  function test_UpdatePricePerFullShare_DoesNotAcceptIncreaseBeforeDelay() public {
+    relayer.setPricePerFullShare(10e18);
+
+    bool updated = relayer.updatePricePerFullShare();
+
+    assertFalse(updated);
+    assertEq(relayer.acceptedPricePerFullShare(), 1e18);
+
+    (uint256 result,) = relayer.getResultWithValidity();
+    assertEq(result, 2e18);
+  }
+
+  function test_UpdatePricePerFullShare_CapsIncreaseAfterDelay() public {
+    relayer.setPricePerFullShare(10e18);
+    vm.warp(block.timestamp + relayer.PRICE_PER_FULL_SHARE_UPDATE_DELAY());
+
+    bool updated = relayer.updatePricePerFullShare();
+
+    assertTrue(updated);
+    assertEq(relayer.acceptedPricePerFullShare(), 1.01e18);
+
+    (uint256 result,) = relayer.getResultWithValidity();
+    assertEq(result, 2.02e18);
+  }
+
+  function test_UpdatePricePerFullShare_AcceptsIncreaseBelowCapAfterDelay() public {
+    relayer.setPricePerFullShare(1.005e18);
+    vm.warp(block.timestamp + relayer.PRICE_PER_FULL_SHARE_UPDATE_DELAY());
+
+    bool updated = relayer.updatePricePerFullShare();
+
+    assertTrue(updated);
+    assertEq(relayer.acceptedPricePerFullShare(), 1.005e18);
+  }
+
+  // --- H-04: read path fails closed to the lower of cached and live share value ---
+
+  function test_GetResultWithValidity_ReflectsVaultLossWithoutUpdate() public {
+    // Vault loses half its value; nobody calls updatePricePerFullShare().
+    relayer.setPricePerFullShare(0.5e18);
+
+    (uint256 result, bool valid) = relayer.getResultWithValidity();
+
+    // min(cached 1e18, live 0.5e18) * 2e8 / 1e8 = 1e18, not the stale 2e18.
+    assertTrue(valid);
+    assertEq(result, 1e18);
+  }
+
+  function test_Read_ReflectsVaultLossWithoutUpdate() public {
+    relayer.setPricePerFullShare(0.5e18);
+
+    assertEq(relayer.read(), 1e18);
+  }
+
+  function test_GetResultWithValidity_KeepsCachedValueWhenLiveIsHigher() public {
+    // A live gain must not raise the reported price (upward cap preserved; M-12 defense intact).
+    relayer.setPricePerFullShare(10e18);
+
+    (uint256 result, bool valid) = relayer.getResultWithValidity();
+
+    assertTrue(valid);
+    assertEq(result, 2e18);
+  }
+
+  function test_GetResultWithValidity_FailsClosedWhenLiveReadReverts() public {
+    relayer.setRevertOnPricePerFullShare(true);
+
+    (uint256 result, bool valid) = relayer.getResultWithValidity();
+
+    // Fail closed; do NOT fall back to the cached value (which would report 2e18).
+    assertEq(result, 0);
+    assertFalse(valid);
+  }
+
+  function test_Read_RevertsWhenLiveReadReverts() public {
+    relayer.setRevertOnPricePerFullShare(true);
+
+    vm.expectRevert(IAbstractVeloVaultRelayer.AbstractVeloVaultRelayer_ZeroPrice.selector);
+    relayer.read();
+  }
+
+  // --- L-17: equal-value update is a true no-op and does not defer the next increase ---
+
+  function test_UpdatePricePerFullShare_NoOpWhenLiveEqualsAccepted() public {
+    uint256 _before = relayer.lastPricePerFullShareUpdateTime();
+    vm.warp(block.timestamp + relayer.PRICE_PER_FULL_SHARE_UPDATE_DELAY() + 1);
+
+    // live == accepted == 1e18
+    bool updated = relayer.updatePricePerFullShare();
+
+    assertFalse(updated);
+    assertEq(relayer.acceptedPricePerFullShare(), 1e18);
+    assertEq(relayer.lastPricePerFullShareUpdateTime(), _before);
+  }
+
+  function test_UpdatePricePerFullShare_NoOpDoesNotDeferNextIncrease() public {
+    vm.warp(block.timestamp + relayer.PRICE_PER_FULL_SHARE_UPDATE_DELAY());
+
+    // A no-op (live == accepted) during a flat window must not reset the timer.
+    relayer.updatePricePerFullShare();
+
+    // A real increase is therefore immediately eligible rather than being pushed out a full delay.
+    relayer.setPricePerFullShare(1.005e18);
+    bool updated = relayer.updatePricePerFullShare();
+
+    assertTrue(updated);
+    assertEq(relayer.acceptedPricePerFullShare(), 1.005e18);
+  }
+
+  // --- H-04: end-to-end front-run through a real DelayedOracle ---
+
+  function test_FrontRun_VaultLossPropagatesThroughDelayedOracleRegardlessOfCaller() public {
+    // Wrap the live relayer in a real DelayedOracle. After a vault loss with NO updatePricePerFullShare() call,
+    // an attacker who drives both delayed-oracle steps cannot keep the stale-high price latched: the relayer
+    // reports the loss-adjusted value to every caller, so the corrected price propagates over the two-step delay.
+    // (Pre-fix the relayer would still report the cached 2e18 and this would settle at 2e18, not 1e18.)
+    uint256 _updateDelay = 1 hours;
+    DelayedOracle delayedOracle = new DelayedOracle(IBaseOracle(address(relayer)), _updateDelay);
+
+    // construction sampled the healthy price: accepted 1e18 * lpPrice 2e8 / 1e8 = 2e18
+    (uint256 _result, bool _valid) = delayedOracle.getResultWithValidity();
+    assertTrue(_valid);
+    assertEq(_result, 2e18);
+
+    // vault loses half its value; nobody calls updatePricePerFullShare()
+    relayer.setPricePerFullShare(0.5e18);
+    // the relayer already reflects the loss on read: min(cached 1e18, live 0.5e18) * 2e8 / 1e8 = 1e18
+    (uint256 _relayerResult,) = relayer.getResultWithValidity();
+    assertEq(_relayerResult, 1e18);
+
+    // an attacker drives both delayed-oracle steps, trying to keep 2e18 latched
+    vm.warp(block.timestamp + _updateDelay);
+    delayedOracle.updateResult();
+    vm.warp(block.timestamp + _updateDelay);
+    delayedOracle.updateResult();
+
+    // the loss has fully propagated to the delayed oracle's current feed
+    (_result, _valid) = delayedOracle.getResultWithValidity();
+    assertTrue(_valid);
+    assertEq(_result, 1e18);
+    assertEq(delayedOracle.read(), 1e18);
+  }
+}

--- a/test/unit/oracles/BeefyVeloVaultRelayerFactory.t.sol
+++ b/test/unit/oracles/BeefyVeloVaultRelayerFactory.t.sol
@@ -73,6 +73,7 @@ contract Unit_BeefyVeloVaultRelayerFactory_DeployBeefyVeloVaultRelayer is Base {
 
   function _mockValues(string memory _symbol) internal {
     _mockSymbol(_symbol);
+    vm.mockCall(address(mockBeefyVault), abi.encodeCall(mockBeefyVault.getPricePerFullShare, ()), abi.encode(1e18));
   }
 
   function test_Revert_Unauthorized() public {

--- a/test/unit/oracles/PessimisticVeloSingleOracle.t.sol
+++ b/test/unit/oracles/PessimisticVeloSingleOracle.t.sol
@@ -1,0 +1,1365 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.20;
+
+import {PessimisticVeloSingleOracle} from '@contracts/oracles/PessimisticVeloSingleOracle.sol';
+import {IVeloPool} from '@interfaces/external/IVeloPool.sol';
+import {IChainlinkOracle} from '@interfaces/oracles/IChainlinkOracle.sol';
+import {HaiTest} from '@test/utils/HaiTest.t.sol';
+
+contract ChainlinkOracleForTest is IChainlinkOracle {
+  uint8 internal immutable _decimals;
+  int256 internal _answer;
+  uint256 internal _updatedAt;
+
+  constructor(uint8 __decimals, int256 __answer, uint256 __updatedAt) {
+    _decimals = __decimals;
+    _answer = __answer;
+    _updatedAt = __updatedAt;
+  }
+
+  function decimals() external view returns (uint8 __decimals) {
+    return _decimals;
+  }
+
+  function description() external pure returns (string memory _description) {
+    return 'ChainlinkOracleForTest';
+  }
+
+  function getAnswer(uint256) external view returns (int256 _latestAnswer) {
+    return _answer;
+  }
+
+  function getRoundData(uint256)
+    external
+    view
+    returns (uint256 _roundId, int256 __answer, uint256 _startedAt, uint256 __updatedAt, uint256 _answeredInRound)
+  {
+    return (1, _answer, _updatedAt, _updatedAt, 1);
+  }
+
+  function getTimestamp(uint256) external view returns (uint256 _timestamp) {
+    return _updatedAt;
+  }
+
+  function latestAnswer() external view returns (int256 _latestAnswer) {
+    return _answer;
+  }
+
+  function latestRound() external pure returns (uint256 _latestRound) {
+    return 1;
+  }
+
+  function latestRoundData()
+    external
+    view
+    returns (uint256 _roundId, int256 __answer, uint256 _startedAt, uint256 __updatedAt, uint256 _answeredInRound)
+  {
+    return (1, _answer, _updatedAt, _updatedAt, 1);
+  }
+
+  function latestTimestamp() external view returns (uint256 _latestTimestamp) {
+    return _updatedAt;
+  }
+
+  function set(int256 __answer, uint256 __updatedAt) external {
+    _answer = __answer;
+    _updatedAt = __updatedAt;
+  }
+}
+
+contract VeloPoolForTest is IVeloPool {
+  error QuoteShouldNotBeCalled();
+
+  string public name = 'VeloPoolForTest';
+  string public symbol = 'VPT';
+  uint8 public decimals = 18;
+  uint256 public totalSupply = 1e18;
+  uint256 public reserve0;
+  uint256 public reserve1;
+  bool public stable;
+  address public token0;
+  address public token1;
+  uint256 internal _decimals0;
+  uint256 internal _decimals1;
+  Observation[] internal _observations;
+
+  constructor(address _token0, address _token1, bool _stable, uint256 __decimals0, uint256 __decimals1) {
+    token0 = _token0;
+    token1 = _token1;
+    stable = _stable;
+    _decimals0 = __decimals0;
+    _decimals1 = __decimals1;
+  }
+
+  function setConstantObservations(uint256 _reserve0, uint256 _reserve1, uint256 _observationCount) external {
+    require(_observationCount > 0);
+    delete _observations;
+    reserve0 = _reserve0;
+    reserve1 = _reserve1;
+
+    uint256 firstTimestamp = block.timestamp - ((_observationCount - 1) * 30 minutes);
+
+    for (uint256 i = 0; i < _observationCount;) {
+      uint256 timestamp = firstTimestamp + (i * 30 minutes);
+      _observations.push(
+        Observation({
+          timestamp: timestamp,
+          reserve0Cumulative: _reserve0 * i * 30 minutes,
+          reserve1Cumulative: _reserve1 * i * 30 minutes
+        })
+      );
+
+      unchecked {
+        i++;
+      }
+    }
+  }
+
+  function setObservationsWithReserves(
+    uint256[] memory _reserve0,
+    uint256[] memory _reserve1,
+    uint256 _period
+  ) external {
+    require(_reserve0.length == _reserve1.length && _reserve0.length > 0 && _period > 0);
+    delete _observations;
+
+    uint256 timestamp = block.timestamp - (_reserve0.length * _period);
+    uint256 reserve0Cumulative;
+    uint256 reserve1Cumulative;
+    _observations.push(
+      Observation({timestamp: timestamp, reserve0Cumulative: reserve0Cumulative, reserve1Cumulative: reserve1Cumulative})
+    );
+
+    for (uint256 i = 0; i < _reserve0.length;) {
+      timestamp += _period;
+      reserve0Cumulative += _reserve0[i] * _period;
+      reserve1Cumulative += _reserve1[i] * _period;
+      _observations.push(
+        Observation({
+          timestamp: timestamp,
+          reserve0Cumulative: reserve0Cumulative,
+          reserve1Cumulative: reserve1Cumulative
+        })
+      );
+
+      unchecked {
+        i++;
+      }
+    }
+
+    reserve0 = _reserve0[_reserve0.length - 1];
+    reserve1 = _reserve1[_reserve1.length - 1];
+  }
+
+  function setObservationsWithPeriods(
+    uint256[] memory _reserve0,
+    uint256[] memory _reserve1,
+    uint256[] memory _periods
+  ) external {
+    require(_reserve0.length == _reserve1.length && _reserve0.length == _periods.length && _reserve0.length > 0);
+    delete _observations;
+
+    uint256 window;
+    for (uint256 i = 0; i < _periods.length;) {
+      require(_periods[i] > 0);
+      window += _periods[i];
+
+      unchecked {
+        i++;
+      }
+    }
+
+    uint256 timestamp = block.timestamp - window;
+    uint256 reserve0Cumulative;
+    uint256 reserve1Cumulative;
+    _observations.push(
+      Observation({timestamp: timestamp, reserve0Cumulative: reserve0Cumulative, reserve1Cumulative: reserve1Cumulative})
+    );
+
+    for (uint256 i = 0; i < _reserve0.length;) {
+      timestamp += _periods[i];
+      reserve0Cumulative += _reserve0[i] * _periods[i];
+      reserve1Cumulative += _reserve1[i] * _periods[i];
+      _observations.push(
+        Observation({
+          timestamp: timestamp,
+          reserve0Cumulative: reserve0Cumulative,
+          reserve1Cumulative: reserve1Cumulative
+        })
+      );
+
+      unchecked {
+        i++;
+      }
+    }
+
+    reserve0 = _reserve0[_reserve0.length - 1];
+    reserve1 = _reserve1[_reserve1.length - 1];
+  }
+
+  function setReserves(uint256 _reserve0, uint256 _reserve1) external {
+    reserve0 = _reserve0;
+    reserve1 = _reserve1;
+  }
+
+  function setTotalSupply(uint256 _totalSupply) external {
+    totalSupply = _totalSupply;
+  }
+
+  function balanceOf(address) external pure returns (uint256 _balance) {
+    return 0;
+  }
+
+  function transfer(address, uint256) external pure returns (bool _success) {
+    return true;
+  }
+
+  function allowance(address, address) external pure returns (uint256 _allowance) {
+    return 0;
+  }
+
+  function approve(address, uint256) external pure returns (bool _success) {
+    return true;
+  }
+
+  function transferFrom(address, address, uint256) external pure returns (bool _success) {
+    return true;
+  }
+
+  function quote(address, uint256, uint256) external pure returns (uint256) {
+    revert QuoteShouldNotBeCalled();
+  }
+
+  function observationLength() external view returns (uint256 _observationLength) {
+    return _observations.length;
+  }
+
+  function observations(uint256 index) external view returns (Observation memory _observation) {
+    return _observations[index];
+  }
+
+  function getReserves() external view returns (uint256 _reserve0, uint256 _reserve1, uint256 _blockTimestampLast) {
+    return (reserve0, reserve1, block.timestamp);
+  }
+
+  function metadata()
+    external
+    view
+    returns (uint256 dec0, uint256 dec1, uint256 r0, uint256 r1, bool st, address t0, address t1)
+  {
+    return (_decimals0, _decimals1, reserve0, reserve1, stable, token0, token1);
+  }
+}
+
+contract Erc4626VaultForTest {
+  address public immutable asset;
+  uint8 public immutable decimals;
+  uint256 public immutable assetsPerShare;
+
+  constructor(address _asset, uint8 _decimals, uint256 _assetsPerShare) {
+    asset = _asset;
+    decimals = _decimals;
+    assetsPerShare = _assetsPerShare;
+  }
+
+  function convertToAssets(uint256 _shares) external view returns (uint256 _assets) {
+    return (_shares * assetsPerShare) / (10 ** decimals);
+  }
+
+  function previewRedeem(uint256 _shares) external view returns (uint256 _assets) {
+    return (_shares * assetsPerShare) / (10 ** decimals);
+  }
+}
+
+contract FeeChargingErc4626VaultForTest {
+  address public immutable asset;
+  uint8 public immutable decimals;
+  uint256 public immutable assetsPerShare;
+  uint256 public immutable redeemFeeBps;
+
+  constructor(address _asset, uint8 _decimals, uint256 _assetsPerShare, uint256 _redeemFeeBps) {
+    asset = _asset;
+    decimals = _decimals;
+    assetsPerShare = _assetsPerShare;
+    redeemFeeBps = _redeemFeeBps;
+  }
+
+  function convertToAssets(uint256 _shares) external view returns (uint256 _assets) {
+    return (_shares * assetsPerShare) / (10 ** decimals);
+  }
+
+  function previewRedeem(uint256 _shares) external view returns (uint256 _assets) {
+    uint256 grossAssets = (_shares * assetsPerShare) / (10 ** decimals);
+    return (grossAssets * (10_000 - redeemFeeBps)) / 10_000;
+  }
+}
+
+contract YearnV2VaultForTest {
+  address public immutable token;
+  uint256 public immutable decimals;
+  uint256 public immutable totalSupply;
+  uint256 public immutable totalAssets;
+  uint256 public immutable lastReport;
+
+  uint256 public constant lockedProfit = 0;
+  uint256 public constant lockedProfitDegradation = 0;
+
+  constructor(address _token, uint256 _decimals, uint256 _totalSupply, uint256 _totalAssets) {
+    token = _token;
+    decimals = _decimals;
+    totalSupply = _totalSupply;
+    totalAssets = _totalAssets;
+    lastReport = block.timestamp;
+  }
+
+  function pricePerShare() external pure returns (uint256 _pricePerShare) {
+    return 1e18;
+  }
+}
+
+abstract contract PessimisticVeloSingleOracleTest is HaiTest {
+  address internal constant SEQUENCER_UPTIME_FEED = 0x371EAD81c9102C9BF4874A9075FFFf170F2Ee389;
+  address internal token0 = label('token0');
+  address internal token1 = label('token1');
+  uint256 internal constant POINTS = 4;
+  uint256 internal constant MAX_TWAP_OBSERVATION_INTERVAL = 1 hours;
+  uint256 internal constant MAX_STABLE_PRICE_DEVIATION = 1.05e18;
+  uint256 internal constant MAX_PESSIMISTIC_PRICE_AGE = 2 hours;
+
+  ChainlinkOracleForTest internal token0Feed;
+  ChainlinkOracleForTest internal token1Feed;
+  VeloPoolForTest internal pool;
+  PessimisticVeloSingleOracle internal oracle;
+
+  function _deployOracle(bool _stable, uint256 _reserve0, uint256 _reserve1) internal {
+    _deployOracle(_stable, 1e18, 1e18, _reserve0, _reserve1);
+  }
+
+  function _deployOracle(
+    bool _stable,
+    uint256 _decimals0,
+    uint256 _decimals1,
+    uint256 _reserve0,
+    uint256 _reserve1
+  ) internal {
+    token0Feed = new ChainlinkOracleForTest(8, 200_000_000, block.timestamp);
+    pool = new VeloPoolForTest(token0, token1, _stable, _decimals0, _decimals1);
+    pool.setConstantObservations(_reserve0, _reserve1, POINTS + 1);
+    oracle = new PessimisticVeloSingleOracle(
+      address(pool),
+      address(token0Feed),
+      address(0),
+      3600,
+      3600,
+      POINTS,
+      MAX_TWAP_OBSERVATION_INTERVAL,
+      MAX_STABLE_PRICE_DEVIATION,
+      MAX_PESSIMISTIC_PRICE_AGE,
+      address(this)
+    );
+  }
+
+  function _deployOracleWithFeeds(
+    bool _stable,
+    uint256 _reserve0,
+    uint256 _reserve1,
+    int256 _price0,
+    int256 _price1
+  ) internal {
+    token0Feed = new ChainlinkOracleForTest(8, _price0, block.timestamp);
+    token1Feed = new ChainlinkOracleForTest(8, _price1, block.timestamp);
+    pool = new VeloPoolForTest(token0, token1, _stable, 1e18, 1e18);
+    pool.setConstantObservations(_reserve0, _reserve1, POINTS + 1);
+    oracle = new PessimisticVeloSingleOracle(
+      address(pool),
+      address(token0Feed),
+      address(token1Feed),
+      3600,
+      3600,
+      POINTS,
+      MAX_TWAP_OBSERVATION_INTERVAL,
+      MAX_STABLE_PRICE_DEVIATION,
+      MAX_PESSIMISTIC_PRICE_AGE,
+      address(this)
+    );
+  }
+
+  function _mockSequencerUp() internal {
+    _mockSequencer(0, block.timestamp - 2 hours);
+  }
+
+  function _mockSequencer(int256 _answer, uint256 _startedAt) internal {
+    vm.clearMockedCalls();
+    vm.mockCall(
+      SEQUENCER_UPTIME_FEED,
+      abi.encodeCall(IChainlinkOracle.latestRoundData, ()),
+      abi.encode(uint256(1), _answer, _startedAt, _startedAt, uint256(1))
+    );
+  }
+
+  function _stableDerivative(uint256 x0, uint256 y) internal pure returns (uint256 derivative) {
+    derivative = 3 * ((x0 * ((y * y) / 1e18)) / 1e18) + ((((x0 * x0) / 1e18) * x0) / 1e18);
+  }
+
+  function _mappingSlot(uint256 _key, uint256 _slot) internal pure returns (bytes32 _storageSlot) {
+    _storageSlot = keccak256(abi.encode(_key, _slot));
+  }
+}
+
+contract Unit_PessimisticVeloSingleOracle_GetTwapPrice is PessimisticVeloSingleOracleTest {
+  function test_Constructor_RevertsWhenMaxTwapObservationIntervalTooShort() public {
+    vm.expectRevert(PessimisticVeloSingleOracle.TwapObservationIntervalTooShort.selector);
+    new PessimisticVeloSingleOracle(
+      address(0),
+      address(0),
+      address(0),
+      3600,
+      3600,
+      POINTS,
+      30 minutes - 1,
+      MAX_STABLE_PRICE_DEVIATION,
+      MAX_PESSIMISTIC_PRICE_AGE,
+      address(this)
+    );
+  }
+
+  function test_Constructor_RevertsWhenMaxStablePriceDeviationTooLow() public {
+    vm.expectRevert(PessimisticVeloSingleOracle.StablePriceDeviationTooLow.selector);
+    new PessimisticVeloSingleOracle(
+      address(0),
+      address(0),
+      address(0),
+      3600,
+      3600,
+      POINTS,
+      MAX_TWAP_OBSERVATION_INTERVAL,
+      1e18 - 1,
+      MAX_PESSIMISTIC_PRICE_AGE,
+      address(this)
+    );
+  }
+
+  function test_Constructor_RevertsWhenMaxStablePriceDeviationTooHigh() public {
+    vm.expectRevert(PessimisticVeloSingleOracle.StablePriceDeviationTooHigh.selector);
+    new PessimisticVeloSingleOracle(
+      address(0),
+      address(0),
+      address(0),
+      3600,
+      3600,
+      POINTS,
+      MAX_TWAP_OBSERVATION_INTERVAL,
+      MAX_STABLE_PRICE_DEVIATION + 1,
+      MAX_PESSIMISTIC_PRICE_AGE,
+      address(this)
+    );
+  }
+
+  function test_Constructor_RevertsWhenMaxPessimisticPriceAgeTooShort() public {
+    vm.expectRevert(PessimisticVeloSingleOracle.PessimisticPriceAgeTooShort.selector);
+    new PessimisticVeloSingleOracle(
+      address(0), address(0), address(0), 3600, 3600, POINTS, MAX_TWAP_OBSERVATION_INTERVAL, 1e18, 0, address(this)
+    );
+  }
+
+  function test_Volatile_ReturnsNoSlippageMarginalPrice() public {
+    _deployOracle(false, 100e18, 200e18);
+    _mockSequencerUp();
+
+    assertEq(oracle.getTwapPrice(token0, 1e18), 2e18);
+    assertEq(oracle.getTwapPrice(token0, 100e18), 200e18);
+    assertEq(oracle.getTwapPrice(token1, 1e18), 0.5e18);
+    assertEq(oracle.getTwapPrice(token1, 100e18), 50e18);
+  }
+
+  function test_Stable_ReturnsNoSlippageMarginalPrice() public {
+    _deployOracle(true, 100e18, 200e18);
+    _mockSequencerUp();
+
+    uint256 expectedToken0ToToken1 = (1e18 * _stableDerivative(200e18, 100e18)) / _stableDerivative(100e18, 200e18);
+    uint256 expectedToken1ToToken0 = (1e18 * _stableDerivative(100e18, 200e18)) / _stableDerivative(200e18, 100e18);
+
+    assertEq(oracle.getTwapPrice(token0, 1e18), expectedToken0ToToken1);
+    assertEq(oracle.getTwapPrice(token1, 1e18), expectedToken1ToToken0);
+    assertApproxEqAbs(oracle.getTwapPrice(token0, 100e18), expectedToken0ToToken1 * 100, 100);
+    assertApproxEqAbs(oracle.getTwapPrice(token1, 100e18), expectedToken1ToToken0 * 100, 100);
+  }
+
+  function test_Stable_HandlesDifferentTokenDecimals() public {
+    _deployOracle(true, 1e6, 1e18, 1000e6, 2000e18);
+    _mockSequencerUp();
+
+    uint256 expectedToken0ToToken1 = (1e18 * _stableDerivative(2000e18, 1000e18)) / _stableDerivative(1000e18, 2000e18);
+
+    assertEq(oracle.getTwapPrice(token0, 1e6), expectedToken0ToToken1);
+    assertApproxEqAbs(oracle.getTwapPrice(token0, 100e6), expectedToken0ToToken1 * 100, 100);
+  }
+
+  function test_StableSingleFeedTwap_DoesNotOverflowForVeryLargeReserveObservations() public {
+    uint256 largeReserve = 50_000_000_000_000e18;
+    _deployOracle(true, largeReserve, largeReserve);
+    _mockSequencerUp();
+
+    assertEq(oracle.getTwapPrice(token0, 1e18), 1e18);
+
+    (uint256 price0, uint256 price1) = oracle.getTokenPrices();
+    assertEq(price0, 200_000_000);
+    assertEq(price1, price0);
+  }
+
+  function test_GetTokenPrices_UsesNoSlippageTwapPrice() public {
+    _deployOracle(false, 100e18, 200e18);
+    _mockSequencerUp();
+
+    (uint256 price0, uint256 price1) = oracle.getTokenPrices();
+
+    assertEq(price0, 200_000_000);
+    assertEq(price1, 100_000_000);
+  }
+
+  function test_GetTokenPrices_DerivesSingleFeedPriceWithoutTinyRawQuoteRounding() public {
+    token0Feed = new ChainlinkOracleForTest(8, 100_000_000, block.timestamp);
+    pool = new VeloPoolForTest(token0, token1, false, 1e6, 1e8);
+    pool.setConstantObservations(600_000e6, 1e8, POINTS + 1);
+    oracle = new PessimisticVeloSingleOracle(
+      address(pool),
+      address(token0Feed),
+      address(0),
+      3600,
+      3600,
+      POINTS,
+      MAX_TWAP_OBSERVATION_INTERVAL,
+      MAX_STABLE_PRICE_DEVIATION,
+      MAX_PESSIMISTIC_PRICE_AGE,
+      address(this)
+    );
+    _mockSequencerUp();
+
+    uint256 tinyRawQuote = oracle.getTwapPrice(token0, 1e6 / 100);
+    (, uint256 price1) = oracle.getTokenPrices();
+
+    assertEq(tinyRawQuote, 1);
+    assertEq(price1, 600_000e8);
+    assertEq((uint256(100_000_000) * 1e8) / (tinyRawQuote * 100), 1_000_000e8);
+  }
+
+  function test_GetTokenPrices_RevertsWhenDerivedTokenPriceRoundsToZero() public {
+    _deployOracle(false, 1e18, 1_000_000_000e18);
+    _mockSequencerUp();
+
+    vm.expectRevert(PessimisticVeloSingleOracle.InvalidDerivedPrice.selector);
+    oracle.getTokenPrices();
+  }
+
+  function test_GetTokenPrices_RevertsWhenTwapDerivedReserveIsZero() public {
+    _deployOracle(false, 1e18, 0);
+    _mockSequencerUp();
+
+    vm.expectRevert(PessimisticVeloSingleOracle.InvalidDerivedPrice.selector);
+    oracle.getTokenPrices();
+  }
+
+  function test_GetTokenPrices_AveragesDerivedTokenPricePerSample() public {
+    _deployOracle(false, 1_000_000e18, 1_000_000e18);
+    _mockSequencerUp();
+
+    uint256[] memory reserve0 = new uint256[](POINTS);
+    uint256[] memory reserve1 = new uint256[](POINTS);
+    reserve0[0] = 10_000e18;
+    reserve1[0] = 1_000_000e18;
+    for (uint256 i = 1; i < POINTS;) {
+      reserve0[i] = 1_000_000e18;
+      reserve1[i] = 1_000_000e18;
+
+      unchecked {
+        i++;
+      }
+    }
+
+    pool.setObservationsWithReserves(reserve0, reserve1, 30 minutes);
+
+    (, uint256 price1) = oracle.getTokenPrices();
+
+    uint256 token0Price = 200_000_000;
+    uint256 amountIn = 1e18 / 100;
+    uint256 expectedPrice1;
+    uint256 averageQuote;
+    for (uint256 i = 0; i < POINTS;) {
+      uint256 amountOut = (amountIn * reserve1[i]) / reserve0[i];
+      expectedPrice1 += (token0Price * 1e18) / (amountOut * 100);
+      averageQuote += amountOut;
+
+      unchecked {
+        i++;
+      }
+    }
+    expectedPrice1 /= POINTS;
+
+    uint256 vulnerablePrice1 = (token0Price * 1e18) / ((averageQuote / POINTS) * 100);
+
+    assertEq(price1, expectedPrice1);
+    assertLt(vulnerablePrice1 * 10, expectedPrice1);
+  }
+
+  function test_GetVolatileGeometricMean_DoesNotTruncateAsymmetricReservesToZero() public {
+    // L-13: normalized reserves (1e36, 1) have a product that fits in uint256, so the geometric mean must be
+    // sqrt(product) = 1e18, not zeroed by the old 1e27 magnitude scaling (which floor-divided the small reserve
+    // to 0 and returned k = 0, bricking pricing with InvalidLpPrice).
+    _deployOracleWithFeeds(false, 1e36, 1, 100_000_000, 100_000_000);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+
+    // k = sqrt(1e36 * 1) = 1e18; p = sqrt(1e8 * 1e16 * 1e8) = 1e16; price = 2*p*k/totalSupply/1e8 = 2e8
+    assertEq(oracle.getCurrentPoolPrice(false), 2e8);
+
+    oracle.updatePrice();
+    assertEq(oracle.dailyLow(oracle.currentDay()), 2e8);
+  }
+
+  function test_GetTokenPrices_AveragesDerivedPriceBeforeFlooring() public {
+    // L-19: per-sample derived prices that each floor to 0 at 8 decimals (0.9 units) but average to a nonzero
+    // value (1.0) must survive. Old code floored every sample first (0+0+0+1)/4 = 0 -> InvalidDerivedPrice;
+    // boosted accumulation keeps sub-unit precision so the average is 1.
+    token0Feed = new ChainlinkOracleForTest(8, 1, block.timestamp);
+    pool = new VeloPoolForTest(token0, token1, false, 1e18, 1e18);
+    oracle = new PessimisticVeloSingleOracle(
+      address(pool),
+      address(token0Feed),
+      address(0),
+      3600,
+      3600,
+      POINTS,
+      MAX_TWAP_OBSERVATION_INTERVAL,
+      MAX_STABLE_PRICE_DEVIATION,
+      MAX_PESSIMISTIC_PRICE_AGE,
+      address(this)
+    );
+    _mockSequencerUp();
+
+    uint256[] memory reserve0 = new uint256[](POINTS);
+    uint256[] memory reserve1 = new uint256[](POINTS);
+    reserve0[0] = 0.9e18;
+    reserve0[1] = 0.9e18;
+    reserve0[2] = 0.9e18;
+    reserve0[3] = 1.3e18;
+    for (uint256 i = 0; i < POINTS;) {
+      reserve1[i] = 1e18;
+      unchecked {
+        i++;
+      }
+    }
+    pool.setObservationsWithReserves(reserve0, reserve1, 30 minutes);
+
+    (uint256 price0, uint256 price1) = oracle.getTokenPrices();
+    assertEq(price0, 1);
+    assertEq(price1, 1); // (0.9 + 0.9 + 0.9 + 1.3) / 4 = 1.0, not floored to 0
+  }
+
+  function test_GetCurrentPoolPrice_VolatileSingleFeedToken0CapUsesTwapReservesNotSpot() public {
+    token0Feed = new ChainlinkOracleForTest(8, 100_000_000, block.timestamp);
+    pool = new VeloPoolForTest(token0, token1, false, 1e6, 1e18);
+    pool.setConstantObservations(1000e6, 1e18, POINTS + 1);
+    oracle = new PessimisticVeloSingleOracle(
+      address(pool),
+      address(token0Feed),
+      address(0),
+      3600,
+      3600,
+      POINTS,
+      MAX_TWAP_OBSERVATION_INTERVAL,
+      MAX_STABLE_PRICE_DEVIATION,
+      MAX_PESSIMISTIC_PRICE_AGE,
+      address(this)
+    );
+    _mockSequencerUp();
+
+    (, uint256 derivedToken1Price) = oracle.getTokenPrices();
+    assertEq(derivedToken1Price, 1000e8);
+    assertApproxEqAbs(oracle.getCurrentPoolPrice(false), 2000e8, 1);
+
+    // M-13: a single-block spot drain of the fed reserve must NOT collapse the price. The cap is derived from
+    // TWAP-averaged reserves, which are unchanged by a spot-only move (the old spot cap would report 20e8).
+    pool.setReserves(10e6, 100e18);
+    assertApproxEqAbs(oracle.getCurrentPoolPrice(false), 2000e8, 1e8);
+
+    // M-11 preserved: a single-block spot inflation must NOT overvalue. The cap still bounds the LP price by
+    // the TWAP-averaged fed-side value (uncapped this would be ~63000e8).
+    pool.setReserves(1_000_000e6, 1e18);
+    assertApproxEqAbs(oracle.getCurrentPoolPrice(false), 2000e8, 1e8);
+  }
+
+  function test_GetCurrentPoolPrice_VolatileSingleFeedToken1CapUsesTwapReservesNotSpot() public {
+    token1Feed = new ChainlinkOracleForTest(8, 100_000_000, block.timestamp);
+    pool = new VeloPoolForTest(token0, token1, false, 1e18, 1e6);
+    pool.setConstantObservations(1e18, 1000e6, POINTS + 1);
+    oracle = new PessimisticVeloSingleOracle(
+      address(pool),
+      address(0),
+      address(token1Feed),
+      3600,
+      3600,
+      POINTS,
+      MAX_TWAP_OBSERVATION_INTERVAL,
+      MAX_STABLE_PRICE_DEVIATION,
+      MAX_PESSIMISTIC_PRICE_AGE,
+      address(this)
+    );
+    _mockSequencerUp();
+
+    (uint256 derivedToken0Price,) = oracle.getTokenPrices();
+    assertEq(derivedToken0Price, 1000e8);
+    assertApproxEqAbs(oracle.getCurrentPoolPrice(false), 2000e8, 1);
+
+    // M-13: spot drain of the fed (token1) reserve must not collapse the price.
+    pool.setReserves(100e18, 10e6);
+    assertApproxEqAbs(oracle.getCurrentPoolPrice(false), 2000e8, 1e8);
+
+    // M-11 preserved: spot inflation must not overvalue.
+    pool.setReserves(1e18, 1_000_000e6);
+    assertApproxEqAbs(oracle.getCurrentPoolPrice(false), 2000e8, 1e8);
+  }
+
+  function test_GetCurrentPoolPrice_StableSingleFeedCapBoundsLpByFedSide() public {
+    // single-feed stable pool: token0 (e.g. BOLD) has a $1 feed, token1 (e.g. LUSD) is TWAP-derived.
+    token0Feed = new ChainlinkOracleForTest(8, 100_000_000, block.timestamp);
+    pool = new VeloPoolForTest(token0, token1, true, 1e18, 1e18);
+    pool.setConstantObservations(1000e18, 1000e18, POINTS + 1);
+    pool.setTotalSupply(2000e18);
+    oracle = new PessimisticVeloSingleOracle(
+      address(pool),
+      address(token0Feed),
+      address(0),
+      3600,
+      3600,
+      POINTS,
+      MAX_TWAP_OBSERVATION_INTERVAL,
+      MAX_STABLE_PRICE_DEVIATION,
+      MAX_PESSIMISTIC_PRICE_AGE,
+      address(this)
+    );
+    _mockSequencerUp();
+
+    uint256 baseline = oracle.getCurrentPoolPrice(false);
+
+    // M-16: with the TWAP-averaged fed reserve unchanged, a spot inflation that the stable formula would price
+    // up is bounded by the fed-side cap, so the reported price stays anchored to the trusted side's value.
+    pool.setReserves(10_000e18, 10_000e18);
+    uint256 cappedSingleFeed = oracle.getCurrentPoolPrice(false);
+    assertApproxEqAbs(cappedSingleFeed, baseline, 1e6);
+
+    // Same pool/reserves as a dual-feed deployment (no cap) is NOT bounded, proving the cap is what limits it.
+    token1Feed = new ChainlinkOracleForTest(8, 100_000_000, block.timestamp);
+    PessimisticVeloSingleOracle dualFeedOracle = new PessimisticVeloSingleOracle(
+      address(pool),
+      address(token0Feed),
+      address(token1Feed),
+      3600,
+      3600,
+      POINTS,
+      MAX_TWAP_OBSERVATION_INTERVAL,
+      MAX_STABLE_PRICE_DEVIATION,
+      MAX_PESSIMISTIC_PRICE_AGE,
+      address(this)
+    );
+    assertGt(dualFeedOracle.getCurrentPoolPrice(false), cappedSingleFeed);
+  }
+
+  function test_GetCurrentPoolPrice_DoesNotOverflowForHugeVolatileReserves() public {
+    uint256 hugeReserve = (type(uint256).max / 1e18) + 1;
+    _deployOracleWithFeeds(false, hugeReserve, hugeReserve, 100_000_000, 100_000_000);
+    pool.setTotalSupply(2 * hugeReserve);
+    _mockSequencerUp();
+
+    assertApproxEqAbs(oracle.getCurrentPoolPrice(false), 1e8, 1);
+  }
+
+  function test_GetTokenPrices_RevertsWhenLatestTwapObservationIsTooOld() public {
+    _deployOracle(false, 1_000_000e18, 1_000_000e18);
+    vm.warp(block.timestamp + 1 hours + 1);
+    token0Feed.set(200_000_000, block.timestamp);
+    _mockSequencerUp();
+
+    vm.expectRevert(PessimisticVeloSingleOracle.TwapObservationTooOld.selector);
+    oracle.getTokenPrices();
+  }
+
+  function test_GetTokenPrices_RevertsWhenTwapObservationIntervalIsTooLong() public {
+    _deployOracle(false, 1_000_000e18, 1_000_000e18);
+    // recovery far enough in the past that the whole window is post-recovery, isolating the interval check
+    _mockSequencer(0, block.timestamp - 3 hours);
+
+    uint256[] memory reserve0 = new uint256[](POINTS);
+    uint256[] memory reserve1 = new uint256[](POINTS);
+    uint256[] memory periods = new uint256[](POINTS);
+    reserve0[0] = 1_000_000e18;
+    reserve1[0] = 1_000_000e18;
+    periods[0] = 1 hours + 1;
+    for (uint256 i = 1; i < POINTS;) {
+      reserve0[i] = 1_000_000e18;
+      reserve1[i] = 1_000_000e18;
+      periods[i] = 30 minutes;
+
+      unchecked {
+        i++;
+      }
+    }
+
+    pool.setObservationsWithPeriods(reserve0, reserve1, periods);
+
+    vm.expectRevert(PessimisticVeloSingleOracle.TwapObservationIntervalTooLong.selector);
+    oracle.getTokenPrices();
+  }
+
+  function test_GetTokenPrices_RevertsWhenTwapWindowStraddlesSequencerRecovery() public {
+    // L-18: observations span the last 2h; the sequencer recovered only 1h ago, so the window's earliest
+    // sampled observation predates recovery and would average frozen pre-outage reserves into the derived price.
+    _deployOracle(false, 1e18, 1e18);
+    _mockSequencer(0, block.timestamp - 1 hours);
+
+    vm.expectRevert(PessimisticVeloSingleOracle.TwapObservationNotPostRecovery.selector);
+    oracle.getTokenPrices();
+  }
+
+  function test_GetTokenPrices_SucceedsWhenTwapWindowFullyPostRecovery() public {
+    // recovery 3h ago: the entire 2h TWAP window is post-recovery, so derivation proceeds
+    _deployOracle(false, 1e18, 1e18);
+    _mockSequencer(0, block.timestamp - 3 hours);
+
+    (uint256 price0, uint256 price1) = oracle.getTokenPrices();
+
+    assertGt(price0, 0);
+    assertGt(price1, 0);
+  }
+
+  function test_GetTwapPrice_RevertsWhenWindowStraddlesSequencerRecovery() public {
+    // the public TWAP quote is gated on the same post-recovery requirement for consistency
+    _deployOracle(false, 1e18, 1e18);
+    _mockSequencer(0, block.timestamp - 1 hours);
+
+    vm.expectRevert(PessimisticVeloSingleOracle.TwapObservationNotPostRecovery.selector);
+    oracle.getTwapPrice(token0, 1e18);
+  }
+
+  function test_GetTokenPrices_AllowsWindowStartingExactlyAtRecovery() public {
+    // L-18 boundary: the gate uses strict `<`, so a window whose earliest observation timestamp EQUALS the
+    // recovery time must be allowed (that first interval accumulates only post-recovery; `<=` would over-reject).
+    _deployOracle(false, 1e18, 1e18);
+    // setConstantObservations(.., POINTS + 1) places the earliest observation at exactly block.timestamp - 2h
+    uint256 _earliestObservationTimestamp = block.timestamp - (POINTS * 30 minutes);
+    _mockSequencer(0, _earliestObservationTimestamp);
+
+    (uint256 price0, uint256 price1) = oracle.getTokenPrices();
+
+    assertGt(price0, 0);
+    assertGt(price1, 0);
+  }
+
+  function test_UpdatePrice_RevertsWhenTwapWindowStraddlesSequencerRecovery() public {
+    // L-18: the recording path (updatePrice -> _getFairReservesPricing -> getTokenPrices) is gated too, so a
+    // contaminated straddling window can never be cached as a daily low.
+    _deployOracle(false, 1e18, 1e18);
+    _mockSequencer(0, block.timestamp - 1 hours);
+    oracle.setOperator(address(this), true);
+
+    vm.expectRevert(PessimisticVeloSingleOracle.TwapObservationNotPostRecovery.selector);
+    oracle.updatePrice();
+  }
+
+  function test_GetCurrentPoolPrice_PessimisticRevertsDuringSequencerGracePeriod() public {
+    _deployOracleWithFeeds(false, 1e18, 1e18, 100_000_000, 100_000_000);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+    oracle.updatePrice();
+
+    _mockSequencer(0, block.timestamp - 30 minutes);
+
+    vm.expectRevert(PessimisticVeloSingleOracle.GracePeriodNotOver.selector);
+    oracle.getCurrentPoolPrice(true);
+  }
+
+  function test_GetCurrentPoolPrice_PessimisticRequiresPostSequencerRecoveryUpdate() public {
+    _deployOracleWithFeeds(false, 1e18, 1e18, 100_000_000, 100_000_000);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+    oracle.updatePrice();
+
+    vm.warp(block.timestamp + 2 hours);
+    uint256 sequencerStartedAt = block.timestamp - 90 minutes;
+    _mockSequencer(0, sequencerStartedAt);
+    token0Feed.set(100_000_000, block.timestamp);
+    token1Feed.set(100_000_000, block.timestamp);
+
+    vm.expectRevert(PessimisticVeloSingleOracle.NoPostSequencerRecoveryPriceUpdate.selector);
+    oracle.getCurrentPoolPrice(true);
+
+    oracle.updatePrice();
+
+    assertGt(oracle.lastPriceUpdateTime(), sequencerStartedAt);
+    assertGt(oracle.getCurrentPoolPrice(true), 0);
+  }
+
+  function test_GetCurrentPoolPrice_PessimisticRevertsWhenLatestUpdateIsStale() public {
+    _deployOracleWithFeeds(false, 1e18, 1e18, 100_000_000, 100_000_000);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+    oracle.updatePrice();
+    uint256 lastPriceUpdateTime = oracle.lastPriceUpdateTime();
+
+    vm.warp(block.timestamp + MAX_PESSIMISTIC_PRICE_AGE + 1);
+    _mockSequencer(0, lastPriceUpdateTime - 2 hours);
+    token0Feed.set(100_000_000, block.timestamp);
+    token1Feed.set(100_000_000, block.timestamp);
+    pool.setConstantObservations(1e18, 1e18, POINTS + 1);
+
+    assertGt(oracle.getCurrentPoolPrice(false), 0);
+
+    vm.expectRevert(PessimisticVeloSingleOracle.PessimisticPriceStale.selector);
+    oracle.getCurrentPoolPrice(true);
+
+    oracle.updatePrice();
+
+    assertGt(oracle.getCurrentPoolPrice(true), 0);
+  }
+
+  function test_GetCurrentPoolPrice_PessimisticRechecksStableDepegForDualFeed() public {
+    _deployOracleWithFeeds(true, 1e18, 1e18, 100_000_000, 100_000_000);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+    oracle.updatePrice();
+
+    // in-band: the pessimistic read serves the cached low
+    uint256 cachedLow = oracle.getCurrentPoolPrice(true);
+    assertGt(cachedLow, 0);
+
+    // a within-band feed move still serves the same cached low (the recheck only gates on the band)
+    token0Feed.set(104_000_000, block.timestamp);
+    assertEq(oracle.getCurrentPoolPrice(true), cachedLow);
+
+    // M-14: once a feed depegs beyond the band, the cached low must no longer be served
+    token0Feed.set(106_000_000, block.timestamp);
+    vm.expectRevert(PessimisticVeloSingleOracle.StablePriceDeviation.selector);
+    oracle.getCurrentPoolPrice(true);
+  }
+
+  function test_GetCurrentPoolPrice_PessimisticDoesNotRecheckStableDepegForSingleFeed() public {
+    // single-feed stable: the depeg recheck is intentionally skipped (the unfed price is the lagging TWAP
+    // value, so the fed-side cap is the relevant defense). The pessimistic read still serves the cached low.
+    token0Feed = new ChainlinkOracleForTest(8, 100_000_000, block.timestamp);
+    pool = new VeloPoolForTest(token0, token1, true, 1e18, 1e18);
+    pool.setConstantObservations(1000e18, 1000e18, POINTS + 1);
+    oracle = new PessimisticVeloSingleOracle(
+      address(pool),
+      address(token0Feed),
+      address(0),
+      3600,
+      3600,
+      POINTS,
+      MAX_TWAP_OBSERVATION_INTERVAL,
+      MAX_STABLE_PRICE_DEVIATION,
+      MAX_PESSIMISTIC_PRICE_AGE,
+      address(this)
+    );
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+    oracle.updatePrice();
+
+    uint256 cachedLow = oracle.getCurrentPoolPrice(true);
+    assertGt(cachedLow, 0);
+
+    // Skew the pool so the TWAP-derived unfed price would now be far off-band. A dual-feed pool would revert
+    // here; a single-feed pool still serves its cached low because the read path skips the deviation recheck.
+    pool.setConstantObservations(1000e18, 4000e18, POINTS + 1);
+    assertEq(oracle.getCurrentPoolPrice(true), cachedLow);
+  }
+
+  function test_GetCurrentPoolPrice_PessimisticDoesNotRecheckDepegForVolatileDualFeed() public {
+    // volatile pools have no peg band; the read path must be unaffected by the stable recheck
+    _deployOracleWithFeeds(false, 1e18, 1e18, 100_000_000, 300_000_000);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+    oracle.updatePrice();
+
+    assertGt(oracle.getCurrentPoolPrice(true), 0);
+  }
+
+  function test_GetCurrentPoolPrice_ThreeDayLowRequiresFullWindow() public {
+    vm.warp(10 days);
+    _deployOracleWithFeeds(false, 1e18, 1e18, 100_000_000, 100_000_000);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+    oracle.setUseThreeDayLow(true);
+
+    oracle.updatePrice();
+
+    vm.expectRevert(PessimisticVeloSingleOracle.PessimisticPriceWindowNotReady.selector);
+    oracle.getCurrentPoolPrice(true);
+
+    vm.warp(block.timestamp + 1 days);
+    _mockSequencerUp();
+    token0Feed.set(100_000_000, block.timestamp);
+    token1Feed.set(100_000_000, block.timestamp);
+    oracle.updatePrice();
+
+    vm.expectRevert(PessimisticVeloSingleOracle.PessimisticPriceWindowNotReady.selector);
+    oracle.getCurrentPoolPrice(true);
+
+    vm.warp(block.timestamp + 1 days);
+    _mockSequencerUp();
+    token0Feed.set(100_000_000, block.timestamp);
+    token1Feed.set(100_000_000, block.timestamp);
+    oracle.updatePrice();
+
+    assertEq(oracle.getCurrentPoolPrice(true), 200_000_000);
+  }
+
+  function test_UpdatePrice_RevertsBeforeRecordingZeroLpPrice() public {
+    _deployOracleWithFeeds(false, 1e18, 1e18, 100_000_000, 100_000_000);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+
+    pool.setReserves(0, 1e18);
+    vm.expectRevert(PessimisticVeloSingleOracle.InvalidLpPrice.selector);
+    oracle.updatePrice();
+    uint256 day = oracle.currentDay();
+
+    assertEq(oracle.dailyUpdates(day), 0);
+    assertEq(oracle.dailyLow(day), 0);
+
+    pool.setReserves(1e18, 1e18);
+    oracle.updatePrice();
+
+    assertEq(oracle.dailyUpdates(day), 1);
+    assertEq(oracle.dailyLow(day), 200_000_000);
+    assertEq(oracle.getCurrentPoolPrice(true), 200_000_000);
+  }
+
+  function test_UpdatePrice_ClampsVolatileSingleFeedDailyLowToFloorInsteadOfReverting() public {
+    _deployOracle(false, 1e18, 1e18);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+
+    oracle.updatePrice();
+    uint256 day = oracle.currentDay();
+
+    assertEq(oracle.dailyLow(day), 400_000_000);
+
+    // L-20/L-22: a drop beyond the per-day bound is clamped to the floor (0.8 * 400e6) and recorded, instead of
+    // reverting and freezing the oracle. The update succeeds and lastPriceUpdateTime advances.
+    pool.setConstantObservations(0.5e18, 1e18, POINTS + 1);
+    oracle.updatePrice();
+
+    assertEq(oracle.dailyUpdates(day), 2);
+    assertEq(oracle.dailyLow(day), 320_000_000);
+    assertEq(oracle.lastPriceUpdateTime(), block.timestamp);
+    assertGt(oracle.getCurrentPoolPrice(true), 0);
+  }
+
+  function test_UpdatePrice_SingleFeedDailyLowDoesNotRatchetWithinDay() public {
+    _deployOracle(false, 1e18, 1e18);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+
+    oracle.updatePrice();
+    uint256 day = oracle.currentDay();
+
+    // L-12: repeated same-day crashes all clamp to the SAME frozen floor (320e6), never 0.8^k of the anchor.
+    for (uint256 i = 0; i < 3;) {
+      pool.setConstantObservations(0.1e18, 1e18, POINTS + 1);
+      oracle.updatePrice();
+      assertEq(oracle.dailyLow(day), 320_000_000);
+
+      unchecked {
+        i++;
+      }
+    }
+    assertEq(oracle.dailyUpdates(day), 4);
+  }
+
+  function test_UpdatePrice_SingleFeedDailyLowStepsDownAcrossDaysOnSustainedCrash() public {
+    vm.warp(10 days);
+    _deployOracle(false, 1e18, 1e18);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+
+    oracle.updatePrice();
+    assertEq(oracle.dailyLow(oracle.currentDay()), 400_000_000);
+
+    // L-20/L-22: a sustained deep crash steps the cached low down 20%/day while the oracle stays live.
+    vm.warp(block.timestamp + 1 days);
+    _mockSequencerUp();
+    token0Feed.set(200_000_000, block.timestamp);
+    pool.setConstantObservations(0.05e18, 1e18, POINTS + 1);
+    oracle.updatePrice();
+    assertEq(oracle.dailyLow(oracle.currentDay()), 320_000_000); // 0.8 * 400e6
+
+    vm.warp(block.timestamp + 1 days);
+    _mockSequencerUp();
+    token0Feed.set(200_000_000, block.timestamp);
+    pool.setConstantObservations(0.05e18, 1e18, POINTS + 1);
+    oracle.updatePrice();
+    assertEq(oracle.dailyLow(oracle.currentDay()), 256_000_000); // 0.8 * 320e6
+
+    assertGt(oracle.getCurrentPoolPrice(true), 0);
+  }
+
+  function test_UpdatePrice_SingleFeedDailyLowConvergesToTrueValueOverDeepCrash() public {
+    // L-20/L-22: a deep crash must converge: the cached low steps down 20%/day, never below the true (capped)
+    // value, the oracle stays live throughout, and once the floor reaches the true value it stops decreasing.
+    vm.warp(30 days);
+    _deployOracle(false, 1e18, 1e18);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+
+    oracle.updatePrice();
+    uint256 _prevLow = oracle.dailyLow(oracle.currentDay());
+    assertEq(_prevLow, 400_000_000);
+
+    // crash the fed reserve hard and hold it; the true (capped) LP value is what the live path now reports
+    pool.setConstantObservations(0.05e18, 1e18, POINTS + 1);
+    uint256 _trueLow = oracle.getCurrentPoolPrice(false);
+    assertLt(_trueLow, _prevLow); // the real value is far below the pre-crash low
+
+    bool _converged;
+    for (uint256 _i = 0; _i < 15;) {
+      vm.warp(block.timestamp + 1 days);
+      _mockSequencerUp();
+      token0Feed.set(200_000_000, block.timestamp);
+      pool.setConstantObservations(0.05e18, 1e18, POINTS + 1);
+      oracle.updatePrice();
+
+      uint256 _curLow = oracle.dailyLow(oracle.currentDay());
+      uint256 _floor = (_prevLow * (10_000 - 2000)) / 10_000; // prior-day low * 0.8
+      uint256 _expected = _floor > _trueLow ? _floor : _trueLow; // clamp floor, but never below true value
+      assertEq(_curLow, _expected);
+      assertLe(_curLow, _prevLow); // monotonic non-increasing
+      assertGe(_curLow, _trueLow); // never underprices below the true value
+      assertGt(oracle.getCurrentPoolPrice(true), 0); // oracle stays live every day
+
+      if (_curLow == _trueLow) _converged = true;
+      _prevLow = _curLow;
+
+      unchecked {
+        _i++;
+      }
+    }
+
+    // after enough days the cached low has converged to the true value and holds there
+    assertTrue(_converged);
+    assertEq(oracle.dailyLow(oracle.currentDay()), _trueLow);
+  }
+
+  function test_UpdatePrice_SingleFeedDailyLowClampsAfterMissedDayWithCompoundedBound() public {
+    vm.warp(10 days);
+    _deployOracle(false, 1e18, 1e18);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+
+    oracle.updatePrice();
+    uint256 day0 = oracle.currentDay();
+    assertEq(oracle.dailyLow(day0), 400_000_000);
+
+    // L-16: skip a whole day, then crash. The clamp still applies (compounded 0.8^2), not a no-op against a
+    // zero reference, so the low cannot drop unbounded after a keeper gap.
+    vm.warp(block.timestamp + 2 days);
+    _mockSequencerUp();
+    token0Feed.set(200_000_000, block.timestamp);
+    pool.setConstantObservations(0.05e18, 1e18, POINTS + 1);
+    oracle.updatePrice();
+    uint256 day2 = oracle.currentDay();
+
+    assertEq(day2, day0 + 2);
+    assertEq(oracle.dailyLow(day2), 256_000_000); // 400e6 * 0.8^2, NOT unbounded
+  }
+
+  function test_UpdatePrice_SingleFeedDailyLowDecayIsCappedAfterLongGap() public {
+    // L-16: a gap longer than MAX_SINGLE_FEED_LOW_DECAY_DAYS (3) caps the compounding at 0.8^3, so the floor
+    // cannot vanish after a long keeper outage (0.8^5 would be ~131e6; the cap keeps it at 0.8^3 = 204.8e6).
+    vm.warp(10 days);
+    _deployOracle(false, 1e18, 1e18);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+
+    oracle.updatePrice();
+    uint256 _day0 = oracle.currentDay();
+    assertEq(oracle.dailyLow(_day0), 400_000_000);
+
+    // skip 4 whole days, then crash on day 5
+    vm.warp(block.timestamp + 5 days);
+    _mockSequencerUp();
+    token0Feed.set(200_000_000, block.timestamp);
+    pool.setConstantObservations(0.05e18, 1e18, POINTS + 1);
+    oracle.updatePrice();
+
+    assertEq(oracle.currentDay(), _day0 + 5);
+    assertEq(oracle.dailyLow(oracle.currentDay()), 204_800_000); // 400e6 * 0.8^3 (capped), not 0.8^5
+  }
+
+  function test_UpdatePrice_SingleFeedDailyLowFloorAnchorsToPriorDayNotFirstReading() public {
+    // L-12: the per-day floor is anchored to the PRIOR-day carry-in low, not the current day's first reading.
+    // Day 2's first reading (350e6) is lower than day 1's (400e6); a same-day crash must clamp to 400e6*0.8=320e6
+    // (prior-day anchor), not 350e6*0.8=280e6 (which a first-reading anchor would wrongly allow).
+    vm.warp(10 days);
+    _deployOracle(false, 1e18, 1e18);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+
+    oracle.updatePrice();
+    assertEq(oracle.dailyLow(oracle.currentDay()), 400_000_000);
+
+    // day 2 first update: a modest drop within bound, recorded as-is (350e6 >= 400e6*0.8 floor)
+    vm.warp(block.timestamp + 1 days);
+    _mockSequencerUp();
+    token0Feed.set(175_000_000, block.timestamp); // half-priced feed -> 350e6 LP price at 1e18/1e18 reserves
+    pool.setConstantObservations(1e18, 1e18, POINTS + 1);
+    oracle.updatePrice();
+    uint256 _day2 = oracle.currentDay();
+    assertEq(oracle.dailyLow(_day2), 350_000_000);
+
+    // same-day crash: clamps to the prior-day-anchored floor (320e6), proving the floor did not re-anchor to 350e6
+    token0Feed.set(175_000_000, block.timestamp);
+    pool.setConstantObservations(0.05e18, 1e18, POINTS + 1);
+    oracle.updatePrice();
+    assertEq(oracle.dailyLow(_day2), 320_000_000); // 400e6 * 0.8, NOT 350e6 * 0.8 = 280e6
+  }
+
+  function test_UpdatePrice_AllowsVolatileSingleFeedDailyLowDropWithinCap() public {
+    _deployOracle(false, 1e18, 1e18);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+
+    oracle.updatePrice();
+    uint256 day = oracle.currentDay();
+
+    pool.setConstantObservations(0.81e18, 1e18, POINTS + 1);
+    oracle.updatePrice();
+
+    assertEq(oracle.dailyUpdates(day), 2);
+    assertGt(oracle.dailyLow(day), 320_000_000);
+    assertLt(oracle.dailyLow(day), 400_000_000);
+  }
+
+  function test_UpdatePrice_DoesNotApplySingleFeedDailyLowCapToDualFeedPool() public {
+    _deployOracleWithFeeds(false, 1e18, 1e18, 100_000_000, 100_000_000);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+
+    oracle.updatePrice();
+    uint256 day = oracle.currentDay();
+
+    pool.setReserves(0.25e18, 1e18);
+    oracle.updatePrice();
+
+    assertEq(oracle.dailyUpdates(day), 2);
+    assertLt(oracle.dailyLow(day), 200_000_000);
+  }
+
+  function test_UpdatePrice_DoesNotApplySingleFeedDailyLowCapToStablePool() public {
+    _deployOracleWithFeeds(true, 1e18, 1e18, 100_000_000, 100_000_000);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+
+    oracle.updatePrice();
+    uint256 day = oracle.currentDay();
+
+    pool.setReserves(0.25e18, 0.25e18);
+    oracle.updatePrice();
+
+    assertEq(oracle.dailyUpdates(day), 2);
+    assertLt(oracle.dailyLow(day), 200_000_000);
+  }
+
+  function test_GetCurrentPoolPrice_PessimisticIgnoresLegacyZeroLow() public {
+    _deployOracleWithFeeds(false, 1e18, 1e18, 100_000_000, 100_000_000);
+    _mockSequencerUp();
+    oracle.setOperator(address(this), true);
+
+    uint256 yesterday = oracle.currentDay();
+    vm.store(address(oracle), _mappingSlot(yesterday, 3), bytes32(uint256(1)));
+    vm.store(address(oracle), bytes32(uint256(4)), bytes32(block.timestamp));
+
+    vm.expectRevert(PessimisticVeloSingleOracle.NoValidPriceUpdates.selector);
+    oracle.getCurrentPoolPrice(true);
+
+    vm.warp(block.timestamp + 1 days);
+    _mockSequencerUp();
+    token0Feed.set(100_000_000, block.timestamp);
+    token1Feed.set(100_000_000, block.timestamp);
+    pool.setConstantObservations(1e18, 1e18, POINTS + 1);
+    oracle.updatePrice();
+    uint256 today = oracle.currentDay();
+
+    assertEq(today, yesterday + 1);
+    assertEq(oracle.dailyLow(yesterday), 0);
+    assertGt(oracle.dailyLow(today), 0);
+    assertEq(oracle.getCurrentPoolPrice(true), oracle.dailyLow(today));
+  }
+
+  function test_GetCurrentVaultPriceV3_UsesVaultShareDecimals() public {
+    _deployOracleWithFeeds(false, 1e18, 1e18, 100_000_000, 100_000_000);
+    _mockSequencerUp();
+
+    Erc4626VaultForTest vault = new Erc4626VaultForTest(address(pool), 6, 1e18);
+    uint256 poolPrice = oracle.getCurrentPoolPrice(false);
+
+    assertEq(oracle.getCurrentVaultPriceV3(address(vault), false), poolPrice);
+  }
+
+  function test_GetCurrentVaultPriceV3_UsesPreviewRedeemNetOfFees() public {
+    _deployOracleWithFeeds(false, 1e18, 1e18, 100_000_000, 100_000_000);
+    _mockSequencerUp();
+
+    FeeChargingErc4626VaultForTest vault = new FeeChargingErc4626VaultForTest(address(pool), 18, 1e18, 1000);
+    uint256 poolPrice = oracle.getCurrentPoolPrice(false);
+
+    assertEq(vault.convertToAssets(1e18), 1e18);
+    assertEq(vault.previewRedeem(1e18), 0.9e18);
+    assertEq(oracle.getCurrentVaultPriceV3(address(vault), false), (poolPrice * 90) / 100);
+  }
+
+  function test_GetCurrentVaultPriceV2_UsesVaultShareDecimals() public {
+    _deployOracleWithFeeds(false, 1e18, 1e18, 100_000_000, 100_000_000);
+    _mockSequencerUp();
+
+    YearnV2VaultForTest vault = new YearnV2VaultForTest(address(pool), 6, 1e6, 1e18);
+    uint256 poolPrice = oracle.getCurrentPoolPrice(false);
+
+    assertEq(oracle.getCurrentVaultPriceV2(address(vault), false), poolPrice);
+  }
+
+  function test_StableLpPrice_AllowsPriceDeviationAtThreshold() public {
+    _deployOracleWithFeeds(true, 1e18, 1e18, 105_000_000, 100_000_000);
+    _mockSequencerUp();
+
+    assertGt(oracle.getCurrentPoolPrice(false), 0);
+  }
+
+  function test_StableLpPrice_RevertsWhenPriceDeviationExceedsThreshold() public {
+    _deployOracleWithFeeds(true, 1e18, 1e18, 106_000_000, 100_000_000);
+    _mockSequencerUp();
+
+    vm.expectRevert(PessimisticVeloSingleOracle.StablePriceDeviation.selector);
+    oracle.getCurrentPoolPrice(false);
+  }
+
+  function test_StableLpPrice_DoesNotOverflowForDeepHighPricedPool() public {
+    _deployOracleWithFeeds(true, 100_000e18, 100_000e18, 3000e8, 3000e8);
+    _mockSequencerUp();
+
+    assertGt(oracle.getCurrentPoolPrice(false), 0);
+  }
+
+  function test_StableLpPrice_DoesNotOverflowWhenLargeReservesStillHaveRepresentableLpPrice() public {
+    _deployOracleWithFeeds(true, 20_000_000_000e18, 20_000_000_000e18, 1e8, 1e8);
+    pool.setTotalSupply(40_000_000_000e18);
+    _mockSequencerUp();
+
+    assertEq(oracle.getCurrentPoolPrice(false), 1e8);
+  }
+
+  function test_StableLpPrice_DoesNotRoundToZeroForSubMillidollarAssets() public {
+    _deployOracleWithFeeds(true, 1e18, 1e18, 50_000, 50_000);
+    _mockSequencerUp();
+
+    assertEq(oracle.getCurrentPoolPrice(false), 100_000);
+  }
+}

--- a/test/unit/oracles/PessimisticVeloSingleOracle.t.sol
+++ b/test/unit/oracles/PessimisticVeloSingleOracle.t.sol
@@ -677,14 +677,16 @@ contract Unit_PessimisticVeloSingleOracle_GetTwapPrice is PessimisticVeloSingleO
     assertEq(derivedToken1Price, 1000e8);
     assertApproxEqAbs(oracle.getCurrentPoolPrice(false), 2000e8, 1);
 
-    // M-13: a single-block spot drain of the fed reserve must NOT collapse the price. The cap is derived from
-    // TWAP-averaged reserves, which are unchanged by a spot-only move (the old spot cap would report 20e8).
+    // M-13: a single-block spot drain of the fed reserve (a k-preserving swap) must NOT move the price. The
+    // fair-reserves value is k-based and the cap is TWAP-anchored (the old spot cap would have reported 20e8).
     pool.setReserves(10e6, 100e18);
     assertApproxEqAbs(oracle.getCurrentPoolPrice(false), 2000e8, 1e8);
 
-    // M-11 preserved: a single-block spot inflation must NOT overvalue. The cap still bounds the LP price by
-    // the TWAP-averaged fed-side value (uncapped this would be ~63000e8).
-    pool.setReserves(1_000_000e6, 1e18);
+    // Codex P1: a single-block balanced flash mint (reserves AND totalSupply scaled together) must NOT move the
+    // price. The cap's trusted-side bound and the fair value it scales both divide by the same supply, so the
+    // supply cancels (the old cap divided a TWAP reserve by the inflated spot supply and underpriced ~halved).
+    pool.setReserves(2000e6, 2e18);
+    pool.setTotalSupply(2e18);
     assertApproxEqAbs(oracle.getCurrentPoolPrice(false), 2000e8, 1e8);
   }
 
@@ -710,21 +712,21 @@ contract Unit_PessimisticVeloSingleOracle_GetTwapPrice is PessimisticVeloSingleO
     assertEq(derivedToken0Price, 1000e8);
     assertApproxEqAbs(oracle.getCurrentPoolPrice(false), 2000e8, 1);
 
-    // M-13: spot drain of the fed (token1) reserve must not collapse the price.
+    // M-13: spot drain (k-preserving swap) of the fed (token1) reserve must not move the price.
     pool.setReserves(100e18, 10e6);
     assertApproxEqAbs(oracle.getCurrentPoolPrice(false), 2000e8, 1e8);
 
-    // M-11 preserved: spot inflation must not overvalue.
-    pool.setReserves(1e18, 1_000_000e6);
+    // Codex P1: a balanced flash mint must not move the price (supply cancels in the cap ratio).
+    pool.setReserves(2e18, 2000e6);
+    pool.setTotalSupply(2e18);
     assertApproxEqAbs(oracle.getCurrentPoolPrice(false), 2000e8, 1e8);
   }
 
-  function test_GetCurrentPoolPrice_StableSingleFeedCapBoundsLpByFedSide() public {
-    // single-feed stable pool: token0 (e.g. BOLD) has a $1 feed, token1 (e.g. LUSD) is TWAP-derived.
+  function _deployStableSingleFeed(uint256 _reserve0, uint256 _reserve1, uint256 _totalSupply) internal {
     token0Feed = new ChainlinkOracleForTest(8, 100_000_000, block.timestamp);
     pool = new VeloPoolForTest(token0, token1, true, 1e18, 1e18);
-    pool.setConstantObservations(1000e18, 1000e18, POINTS + 1);
-    pool.setTotalSupply(2000e18);
+    pool.setConstantObservations(_reserve0, _reserve1, POINTS + 1);
+    pool.setTotalSupply(_totalSupply);
     oracle = new PessimisticVeloSingleOracle(
       address(pool),
       address(token0Feed),
@@ -737,19 +739,35 @@ contract Unit_PessimisticVeloSingleOracle_GetTwapPrice is PessimisticVeloSingleO
       MAX_PESSIMISTIC_PRICE_AGE,
       address(this)
     );
+  }
+
+  function test_GetCurrentPoolPrice_StableSingleFeedCapResistsFlashMint() public {
+    // single-feed stable pool (e.g. BOLD fed / LUSD derived), balanced.
+    _deployStableSingleFeed(1000e18, 1000e18, 2000e18);
     _mockSequencerUp();
 
     uint256 baseline = oracle.getCurrentPoolPrice(false);
 
-    // M-16: with the TWAP-averaged fed reserve unchanged, a spot inflation that the stable formula would price
-    // up is bounded by the fed-side cap, so the reported price stays anchored to the trusted side's value.
-    pool.setReserves(10_000e18, 10_000e18);
-    uint256 cappedSingleFeed = oracle.getCurrentPoolPrice(false);
-    assertApproxEqAbs(cappedSingleFeed, baseline, 1e6);
+    // Codex P1 (underprice): a balanced flash mint doubles spot reserves AND totalSupply while the TWAP reserves
+    // lag. The price must stay at baseline. The OLD cap divided a TWAP reserve by the inflated spot supply and
+    // would have underpriced to ~half here; option 1 cancels the supply in the cap ratio.
+    pool.setReserves(2000e18, 2000e18);
+    pool.setTotalSupply(4000e18);
+    assertApproxEqAbs(oracle.getCurrentPoolPrice(false), baseline, baseline / 1000);
+  }
 
-    // Same pool/reserves as a dual-feed deployment (no cap) is NOT bounded, proving the cap is what limits it.
-    token1Feed = new ChainlinkOracleForTest(8, 100_000_000, block.timestamp);
-    PessimisticVeloSingleOracle dualFeedOracle = new PessimisticVeloSingleOracle(
+  function test_GetCurrentPoolPrice_StableSingleFeedCapBindsAndResistsFlashBurn() public {
+    // TWAP imbalanced toward the unfed (token1) side so the fed-side cap binds and marks the price down,
+    // while the derived price stays inside the 1.05 deviation band.
+    _deployStableSingleFeed(900e18, 1100e18, 2000e18);
+    _mockSequencerUp();
+
+    (, uint256 derivedPrice1) = oracle.getTokenPrices();
+    uint256 cappedPrice = oracle.getCurrentPoolPrice(false);
+
+    // confirm the cap is actually binding: an identical DUAL-feed pool (no cap, same derived price) is higher
+    token1Feed = new ChainlinkOracleForTest(8, int256(derivedPrice1), block.timestamp);
+    PessimisticVeloSingleOracle dualFeed = new PessimisticVeloSingleOracle(
       address(pool),
       address(token0Feed),
       address(token1Feed),
@@ -761,7 +779,14 @@ contract Unit_PessimisticVeloSingleOracle_GetTwapPrice is PessimisticVeloSingleO
       MAX_PESSIMISTIC_PRICE_AGE,
       address(this)
     );
-    assertGt(dualFeedOracle.getCurrentPoolPrice(false), cappedSingleFeed);
+    assertGt(dualFeed.getCurrentPoolPrice(false), cappedPrice);
+
+    // Codex P1 (overvalue bypass): a balanced flash burn halves spot reserves AND supply while the TWAP reserves
+    // lag. The markdown must persist. The OLD cap (TWAP reserve / deflated spot supply) would have RISEN and let
+    // the overvalued price through; option 1 cancels the supply in the cap ratio.
+    pool.setReserves(450e18, 550e18);
+    pool.setTotalSupply(1000e18);
+    assertApproxEqAbs(oracle.getCurrentPoolPrice(false), cappedPrice, cappedPrice / 1000);
   }
 
   function test_GetCurrentPoolPrice_DoesNotOverflowForHugeVolatileReserves() public {

--- a/test/unit/oracles/YearnVeloVaultRelayerFactory.t.sol
+++ b/test/unit/oracles/YearnVeloVaultRelayerFactory.t.sol
@@ -73,6 +73,7 @@ contract Unit_YearnVeloVaultRelayerFactory_DeployYearnVeloVaultRelayer is Base {
 
   function _mockValues(string memory _symbol) internal {
     _mockSymbol(_symbol);
+    vm.mockCall(address(mockYearnVault), abi.encodeCall(mockYearnVault.pricePerShare, ()), abi.encode(1e18));
   }
 
   function test_Revert_Unauthorized() public {


### PR DESCRIPTION
Squashes the whole pessimistic Velo LP single-oracle work into one commit on top of dev. It's everything that isn't
  on dev yet — the v1 review (#152 and the follow-ups) plus the v2 fixes from the review.

  Heads up: the v1 review branch was never merged to dev, so this PR carries it along too.

  Already in from v1:
  - single-feed TWAP pricing excludes quote slippage
  - overflow handling for deep stable pools
  - the #152 review pass
  - zero share prices invalidate the cached vault price

  v2 review fixes:
  - H-04 / L-17 – relayer prices off min(cached, live) price-per-share and fails closed if the vault read reverts; a
  no-op update doesn't reset the repricing timer anymore
  - M-13 / M-16 – the single-feed price cap uses TWAP-averaged reserves instead of spot, and I extended it to stable
  pools too. Stops someone moving the cap in a single block, and covers the case where the unfed token (e.g. LUSD)
  depegs but its TWAP price is still lagging
  - M-14 – dual-feed stable pools re-check the peg band on the read path, so a live depeg invalidates the cached low
  right away instead of serving it until it ages out
  - L-12 / L-16 / L-20 / L-22 – reworked the single-feed daily-low clamp to be fail-soft. Floor is anchored to the
  prior day's low, can't ratchet down within a day, decays sanely after a missed day, and a real crash no longer
  freezes the oracle — it steps the low down and stays live
  - L-13 / L-19 – geomean no longer returns zero for valid reserves; the TWAP-derived price rounds once at the end
  instead of per-sample
  - L-18 – the TWAP window now has to be fully past the last sequencer recovery
  - L-15 – OracleJob actually propagates an invalidation through to the SAFE engine now, without letting keepers farm
  rewards on no-ops

  Didn't touch: H-05, M-04, M-06, M-12, L-02, L-10, L-11, L-14, L-21, L-23 — either already fixed, accepted, or didn't
  hold up on a closer look. Reasoning is in the review doc.

  One thing to be aware of: a few of these (M-14, L-18, L-15) make the oracle fail closed faster. That's intended, but
  it does mean a sustained stable depeg can halt that collateral until it recovers or we swap the oracle out. Flagging
  so it's not a surprise.

  Testing: unit tests for each fix plus a handful of integration ones — a real DelayedOracle front-run for H-04, the
  two-cycle invalidation for L-15, the recovery boundary for L-18, and a multi-day crash to show the clamp converges. I
  checked the two integration tests actually fail if you revert the fix. Oracle + jobs suites are green; the leftover
  failures in the full unit run are pre-existing fuzz/testFail noise unrelated to the oracle (they're on the base too).